### PR TITLE
fix(audio-player): Release media controller on screen disposal

### DIFF
--- a/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerScreen.kt
+++ b/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -132,6 +133,12 @@ fun AudioPlayerScreen(
             .collect { newValue ->
                 isPlaying = newValue
             }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            mediaController?.release()
+        }
     }
 
     AudioPlayerScreen(


### PR DESCRIPTION
- Added `DisposableEffect` to release the `mediaController` when the `AudioPlayerScreen` is disposed.
- Ensures resources are properly released when the screen is no longer in use.

CLOSES #19 