### PR TITLE
feat(analytics): Firebase Analytics integration for events and parame…

### DIFF
--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseEventProvider.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseEventProvider.kt
@@ -15,4 +15,12 @@ import com.kesicollection.core.app.AnalyticsWrapper
 object FirebaseEventProvider: AnalyticsWrapper.Event {
     override val screenView: String
         get() = FirebaseAnalytics.Event.SCREEN_VIEW
+    override val selectItem: String
+        get() = FirebaseAnalytics.Event.SELECT_ITEM
+    override val tryAgain: String
+        get() = "try_again"
+    override val playAudioPlayer: String
+        get() = "play_audio_player"
+    override val pauseAudioPlayer: String
+        get() = "pause_audio_player"
 }

--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseParamProvider.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseParamProvider.kt
@@ -18,4 +18,10 @@ object FirebaseParamProvider : AnalyticsWrapper.Param {
         get() = FirebaseAnalytics.Param.SCREEN_NAME
     override val screenClass: String
         get() = FirebaseAnalytics.Param.SCREEN_CLASS
+    override val itemId: String
+        get() = FirebaseAnalytics.Param.ITEM_ID
+    override val itemName: String
+        get() = FirebaseAnalytics.Param.ITEM_NAME
+    override val contentType: String
+        get() = FirebaseAnalytics.Param.CONTENT_TYPE
 }

--- a/core/app/src/main/kotlin/com/kesicollection/core/app/AnalyticsWrapper.kt
+++ b/core/app/src/main/kotlin/com/kesicollection/core/app/AnalyticsWrapper.kt
@@ -41,6 +41,10 @@ interface AnalyticsWrapper {
      */
     interface Event {
         val screenView: String
+        val selectItem: String
+        val tryAgain: String
+        val playAudioPlayer: String
+        val pauseAudioPlayer: String
     }
 
     /**
@@ -52,6 +56,9 @@ interface AnalyticsWrapper {
     interface Param {
         val screenName: String
         val screenClass: String
+        val itemId: String
+        val itemName: String
+        val contentType: String
     }
 
     /**

--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
@@ -141,7 +141,14 @@ fun ArticleScreen(
             uiState = uiState,
             onNavigateUp = onNavigateUp,
             onPodcastClick = onPodcastClick,
-            onTryAgain = { viewModel.sendIntent(Intent.FetchArticle(articleId)) },
+            onTryAgain = {
+                analytics.logEvent(
+                    analytics.event.tryAgain, mapOf(
+                        analytics.param.itemId to articleId,
+                    )
+                )
+                viewModel.sendIntent(Intent.FetchArticle(articleId))
+            },
             modifier = modifier,
         )
     }

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
@@ -111,8 +111,23 @@ fun ArticlesScreen(
         ArticlesScreen(
             modifier = modifier,
             onArticleClick = onArticleClick,
-            onBookmarkClick = viewModel::sendIntent,
-            onTryAgain = viewModel::sendIntent,
+            onBookmarkClick = {
+                analytics.logEvent(
+                    analytics.event.selectItem, mapOf(
+                        analytics.param.itemId to it.articleId,
+                        analytics.param.contentType to "article"
+                    )
+                )
+                viewModel.sendIntent(it)
+            },
+            onTryAgain = {
+                analytics.logEvent(
+                    analytics.event.tryAgain, mapOf(
+                        analytics.param.screenName to "articles",
+                    )
+                )
+                viewModel.sendIntent(it)
+            },
             uiState = uiState,
         )
     }

--- a/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerScreen.kt
+++ b/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerScreen.kt
@@ -151,8 +151,20 @@ fun AudioPlayerScreen(
         isPlaying = { isPlaying },
         onPlayPauseClick = {
             if (isPlaying) {
+                analytics.logEvent(
+                    analytics.event.pauseAudioPlayer, mapOf(
+                        analytics.param.itemId to fileName,
+                        analytics.param.contentType to "podcast"
+                    )
+                )
                 mediaController?.pause()
             } else {
+                analytics.logEvent(
+                    analytics.event.playAudioPlayer, mapOf(
+                        analytics.param.itemId to fileName,
+                        analytics.param.contentType to "podcast"
+                    )
+                )
                 mediaController?.play()
             }
         }


### PR DESCRIPTION
…ters

- Added `FirebaseEventProvider` and `FirebaseParamProvider` to map events and parameters to Firebase Analytics constants.
- Defined `Event` and `Param` interfaces in `AnalyticsWrapper` for event and parameter names.
- Implemented analytics logging for `tryAgain` in `ArticleScreen` and `ArticlesScreen`.
- Implemented analytics logging for `playAudioPlayer` and `pauseAudioPlayer` in `AudioPlayerScreen`.
- Implemented analytics logging for `selectItem` in `ArticlesScreen`
- Added `itemId`, `itemName` and `contentType` parameters in `FirebaseParamProvider` and `AnalyticsWrapper.Param`.
- Added `tryAgain`, `playAudioPlayer` and `pauseAudioPlayer` event in `FirebaseEventProvider` and `AnalyticsWrapper.Event`.
- Added `selectItem` event in `FirebaseEventProvider` and `AnalyticsWrapper.Event`.

CLOSES #30 