### PR TITLE
feat(ads): Track ad impressions with Firebase Analytics

### DIFF
--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseEventProvider.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseEventProvider.kt
@@ -23,4 +23,6 @@ object FirebaseEventProvider: AnalyticsWrapper.Event {
         get() = "play_audio_player"
     override val pauseAudioPlayer: String
         get() = "pause_audio_player"
+    override val adImpression: String
+        get() = FirebaseAnalytics.Event.AD_IMPRESSION
 }

--- a/core/app/src/main/kotlin/com/kesicollection/core/app/AnalyticsWrapper.kt
+++ b/core/app/src/main/kotlin/com/kesicollection/core/app/AnalyticsWrapper.kt
@@ -45,6 +45,7 @@ interface AnalyticsWrapper {
         val tryAgain: String
         val playAudioPlayer: String
         val pauseAudioPlayer: String
+        val adImpression: String
     }
 
     /**

--- a/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/component/KAdView.kt
+++ b/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/component/KAdView.kt
@@ -6,22 +6,36 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdView
+import com.kesicollection.core.uisystem.LocalApp
 
 @SuppressLint("MissingPermission")
 @Composable
 fun KAdView(
     modifier: Modifier = Modifier,
     adUnitId: String,
+    screenName: String
 ) {
     val context = LocalContext.current
+    val analytics = LocalApp.current.analytics
     AndroidView(
         modifier = modifier,
         factory = {
             AdView(context).apply {
                 setAdSize(com.google.android.gms.ads.AdSize.BANNER)
                 this.adUnitId = adUnitId
+                this.adListener = object : AdListener() {
+                    override fun onAdClicked() {
+                        super.onAdClicked()
+                        analytics.logEvent(
+                            analytics.event.adImpression, mapOf(
+                                analytics.param.screenName to screenName
+                            )
+                        )
+                    }
+                }
                 layoutParams = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.WRAP_CONTENT

--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
@@ -322,6 +322,7 @@ internal fun ArticleScreen(
                 }
                 KAdView(
                     adUnitId = BuildConfig.AD_UNIT_ARTICLE,
+                    screenName = "Article",
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = safeContent.calculateBottomPadding())

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
@@ -211,6 +211,7 @@ internal fun ArticlesScreen(
                 }
                 KAdView(
                     adUnitId = BuildConfig.AD_UNIT_ARTICLES,
+                    screenName = "Articles",
                     modifier = Modifier
                         .fillMaxWidth()
                 )


### PR DESCRIPTION
- Added `adImpression` event to `FirebaseEventProvider` and `AnalyticsWrapper` to track ad impressions.
- Implemented tracking of `adImpression` when a user clicks on an ad in `KAdView`.
- Included the screen name as a parameter in the `adImpression` event.
- `ArticleScreen` and `ArticlesScreen` now sends `screenName` param to `KAdView`.

CLOSES #32 