### PR TITLE
feat(crashlytics): Firebase Crashlytics integration

### DIFF
--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/KesiAndroidAppManager.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/KesiAndroidAppManager.kt
@@ -2,6 +2,7 @@ package com.kesicollection.kesiandroid
 
 import com.kesicollection.core.app.AnalyticsWrapper
 import com.kesicollection.core.app.AppManager
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.app.Logger
 import javax.inject.Inject
 
@@ -14,13 +15,17 @@ import javax.inject.Inject
  *
  * @property appLogger The [Logger] instance used for application-wide logging.
  * @property analyticsWrapper The [AnalyticsWrapper] instance used for tracking events and user behavior.
+ * @property crashlyticsWrapper The [CrashlyticsWrapper] instance used for tracking errors.
  */
 class KesiAndroidAppManager @Inject constructor(
     private val appLogger: Logger,
     private val analyticsWrapper: AnalyticsWrapper,
+    private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : AppManager {
     override val logger: Logger
         get() = appLogger
     override val analytics: AnalyticsWrapper
         get() = analyticsWrapper
+    override val crashlytics: CrashlyticsWrapper
+        get() = crashlyticsWrapper
 }

--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/crashlytics/FirebaseCrashlyticsProvider.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/crashlytics/FirebaseCrashlyticsProvider.kt
@@ -1,0 +1,8 @@
+package com.kesicollection.kesiandroid.crashlytics
+
+import com.kesicollection.core.app.CrashlyticsWrapper
+
+object FirebaseCrashlyticsProvider : CrashlyticsWrapper.Params {
+    override val screenName: String
+        get() = "screen_name"
+}

--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/crashlytics/FirebaseCrashlyticsWrapper.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/crashlytics/FirebaseCrashlyticsWrapper.kt
@@ -1,0 +1,29 @@
+package com.kesicollection.kesiandroid.crashlytics
+
+import android.util.Log
+import com.google.firebase.crashlytics.BuildConfig
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.recordException
+import com.kesicollection.core.app.CrashlyticsWrapper
+import javax.inject.Inject
+
+class FirebaseCrashlyticsWrapper @Inject constructor(
+    private val crashlytics: FirebaseCrashlytics,
+    private val crashlyticsParams: CrashlyticsWrapper.Params
+) : CrashlyticsWrapper {
+
+    override val params: CrashlyticsWrapper.Params
+        get() = crashlyticsParams
+
+    override fun recordException(exception: Exception, params: Map<String, String>?) {
+        if (BuildConfig.DEBUG) {
+            Log.e("FirebaseCrashlyticsWrapper", "recordException: ${exception.message}", exception)
+        } else {
+            crashlytics.recordException(exception) {
+                params?.let {
+                    it.forEach { entry -> key(entry.key, entry.value) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/di/CrashlyticsModule.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/di/CrashlyticsModule.kt
@@ -1,0 +1,37 @@
+package com.kesicollection.kesiandroid.di
+
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.crashlytics
+import com.kesicollection.core.app.CrashlyticsWrapper
+import com.kesicollection.kesiandroid.crashlytics.FirebaseCrashlyticsProvider
+import com.kesicollection.kesiandroid.crashlytics.FirebaseCrashlyticsWrapper
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CrashlyticsModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCrashlyticsWrapper(
+        firebaseCrashlyticsWrapper: FirebaseCrashlyticsWrapper
+    ): CrashlyticsWrapper
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun providesFirebaseCrashlytics(): FirebaseCrashlytics = Firebase.crashlytics
+
+        @Provides
+        @Singleton
+        fun providesFirebaseCrashlyticsProvider(): CrashlyticsWrapper.Params =
+            FirebaseCrashlyticsProvider
+    }
+}

--- a/core/app/src/main/kotlin/com/kesicollection/core/app/AppManager.kt
+++ b/core/app/src/main/kotlin/com/kesicollection/core/app/AppManager.kt
@@ -3,4 +3,5 @@ package com.kesicollection.core.app
 interface AppManager {
     val logger: Logger
     val analytics: AnalyticsWrapper
+    val crashlytics: CrashlyticsWrapper
 }

--- a/core/app/src/main/kotlin/com/kesicollection/core/app/CrashlyticsWrapper.kt
+++ b/core/app/src/main/kotlin/com/kesicollection/core/app/CrashlyticsWrapper.kt
@@ -1,0 +1,13 @@
+package com.kesicollection.core.app
+
+import java.lang.Exception
+
+interface CrashlyticsWrapper {
+
+    val params: Params
+    fun recordException(exception: Exception, params: Map<String, String>? = null)
+
+    interface Params {
+        val screenName: String
+    }
+}


### PR DESCRIPTION
- Added `CrashlyticsWrapper` interface in core to abstract crash reporting.
- Implemented `FirebaseCrashlyticsWrapper` that uses Firebase Crashlytics for crash reporting.
- Added `CrashlyticsModule` to provide `FirebaseCrashlytics` and `FirebaseCrashlyticsProvider` instances.
- Created `FirebaseCrashlyticsProvider` to provide crashlytics params.
- Updated `KesiAndroidAppManager` to include `CrashlyticsWrapper`.
- Added logic to log errors in debug and release using `FirebaseCrashlytics`.
- Added a `Params` interface to `CrashlyticsWrapper` for custom params.
- Updated `AppManager` to include `crashlytics` parameter.

CLOSES #34