### PR TITLE
feat(crashlytics): Crashlytics integration

### DIFF
--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/crashlytics/FirebaseCrashlyticsProvider.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/crashlytics/FirebaseCrashlyticsProvider.kt
@@ -5,4 +5,8 @@ import com.kesicollection.core.app.CrashlyticsWrapper
 object FirebaseCrashlyticsProvider : CrashlyticsWrapper.Params {
     override val screenName: String
         get() = "screen_name"
+    override val className: String
+        get() = "class_name"
+    override val action: String
+        get() = "action"
 }

--- a/core/app/src/main/kotlin/com/kesicollection/core/app/CrashlyticsWrapper.kt
+++ b/core/app/src/main/kotlin/com/kesicollection/core/app/CrashlyticsWrapper.kt
@@ -9,5 +9,7 @@ interface CrashlyticsWrapper {
 
     interface Params {
         val screenName: String
+        val className: String
+        val action: String
     }
 }

--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/intent/FetchArticleIntentProcessor.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/intent/FetchArticleIntentProcessor.kt
@@ -1,5 +1,6 @@
 package com.kesicollection.feature.article.intent
 
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.model.ContentSection
 import com.kesicollection.core.uisystem.ErrorState
 import com.kesicollection.core.uisystem.IntentProcessor
@@ -39,6 +40,7 @@ import com.kesicollection.feature.article.uimodel.UiPodcast
 class FetchArticleIntentProcessor(
     private val articleId: String,
     private val getArticleByIdUseCase: GetArticleByIdUseCase,
+    private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessor<UiArticleState> {
     override suspend fun processIntent(reducer: (Reducer<UiArticleState>) -> Unit) {
         reducer { copy(isLoading = true, error = null) }
@@ -67,6 +69,11 @@ class FetchArticleIntentProcessor(
                 )
             }
         } catch (e: Exception) {
+            crashlyticsWrapper.recordException(e, mapOf(
+                crashlyticsWrapper.params.screenName to "Article",
+                crashlyticsWrapper.params.className to "FetchArticleIntentProcessor",
+                crashlyticsWrapper.params.action to "fetch",
+            ))
             reducer {
                 copy(
                     isLoading = false,

--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/intent/IntentProcessorFactory.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/intent/IntentProcessorFactory.kt
@@ -1,5 +1,6 @@
 package com.kesicollection.feature.article.intent
 
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.uisystem.IntentProcessor
 import com.kesicollection.core.uisystem.IntentProcessorFactory
 import com.kesicollection.data.usecase.GetArticleByIdUseCase
@@ -22,12 +23,14 @@ import javax.inject.Singleton
 @Singleton
 class DefaultIntentProcessorFactory @Inject constructor(
     private val getArticleByIdUseCase: GetArticleByIdUseCase,
+    private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessorFactory<UiArticleState, Intent> {
     override fun create(intent: Intent): IntentProcessor<UiArticleState> {
         return when (intent) {
             is Intent.FetchArticle -> FetchArticleIntentProcessor(
                 articleId = intent.id,
-                getArticleByIdUseCase = getArticleByIdUseCase
+                getArticleByIdUseCase = getArticleByIdUseCase,
+                crashlyticsWrapper = crashlyticsWrapper,
             )
         }
     }

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/BookmarkArticleIntentProcessor.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/BookmarkArticleIntentProcessor.kt
@@ -3,6 +3,7 @@ package com.kesicollection.articles.intentprocessor
 import com.kesicollection.articles.ArticlesErrors
 import com.kesicollection.articles.UiArticlesState
 import com.kesicollection.articles.model.asUiArticle
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.uisystem.ErrorState
 import com.kesicollection.core.uisystem.IntentProcessor
 import com.kesicollection.core.uisystem.Reducer
@@ -26,6 +27,7 @@ class BookmarkArticleIntentProcessor(
     private val bookmarkArticleByIdUseCase: BookmarkArticleByIdUseCase,
     private val isArticleBookmarkedUseCase: IsArticleBookmarkedUseCase,
     private val getArticlesUseCase: GetArticlesUseCase,
+    private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessor<UiArticlesState> {
     override suspend fun processIntent(reducer: (Reducer<UiArticlesState>) -> Unit) {
         reducer {
@@ -42,6 +44,13 @@ class BookmarkArticleIntentProcessor(
                 copy(articles = articles)
             }
         } catch (e: Exception) {
+            crashlyticsWrapper.recordException(
+                e, mapOf(
+                    crashlyticsWrapper.params.screenName to "Articles",
+                    crashlyticsWrapper.params.className to "BookmarkArticleIntentProcessor",
+                    crashlyticsWrapper.params.action to "bookmark",
+                )
+            )
             reducer {
                 copy(
                     isLoading = false,

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/FetchArticlesIntentProcessor.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/FetchArticlesIntentProcessor.kt
@@ -3,6 +3,7 @@ package com.kesicollection.articles.intentprocessor
 import com.kesicollection.articles.ArticlesErrors
 import com.kesicollection.articles.UiArticlesState
 import com.kesicollection.articles.model.asUiArticle
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.uisystem.ErrorState
 import com.kesicollection.core.uisystem.IntentProcessor
 import com.kesicollection.core.uisystem.Reducer
@@ -47,6 +48,7 @@ import com.kesicollection.data.usecase.IsArticleBookmarkedUseCase
 class FetchArticlesIntentProcessor(
     private val getArticlesUseCase: GetArticlesUseCase,
     private val isArticleBookmarkedUseCase: IsArticleBookmarkedUseCase,
+    private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessor<UiArticlesState> {
     override suspend fun processIntent(reducer: (Reducer<UiArticlesState>) -> Unit) {
         reducer { copy(isLoading = true, error = null) }
@@ -61,6 +63,14 @@ class FetchArticlesIntentProcessor(
                 )
             }
         } catch (e: Exception) {
+            crashlyticsWrapper.recordException(
+                exception = e,
+                params = mapOf(
+                    crashlyticsWrapper.params.screenName to "Articles",
+                    crashlyticsWrapper.params.className to "FetchArticlesIntentProcessor",
+                    crashlyticsWrapper.params.action to "fetch",
+                )
+            )
             reducer {
                 copy(
                     isLoading = false,

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/IntentProcessorFactory.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/IntentProcessorFactory.kt
@@ -2,6 +2,7 @@ package com.kesicollection.articles.intentprocessor
 
 import com.kesicollection.articles.Intent
 import com.kesicollection.articles.UiArticlesState
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.uisystem.IntentProcessor
 import com.kesicollection.core.uisystem.IntentProcessorFactory
 import com.kesicollection.data.usecase.BookmarkArticleByIdUseCase
@@ -24,6 +25,7 @@ class DefaultIntentProcessorFactory @Inject constructor(
     private val getArticlesUseCase: GetArticlesUseCase,
     private val isArticleBookmarkedUseCase: IsArticleBookmarkedUseCase,
     private val bookmarkArticleByIdUseCase: BookmarkArticleByIdUseCase,
+    private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessorFactory<UiArticlesState, Intent> {
 
     // NOTE: Two options here: Either make some how lightweight intent processor instances
@@ -35,6 +37,7 @@ class DefaultIntentProcessorFactory @Inject constructor(
             Intent.FetchArticles -> FetchArticlesIntentProcessor(
                 getArticlesUseCase = getArticlesUseCase,
                 isArticleBookmarkedUseCase = isArticleBookmarkedUseCase,
+                crashlyticsWrapper = crashlyticsWrapper,
             )
 
             is Intent.BookmarkClicked -> BookmarkArticleIntentProcessor(
@@ -42,6 +45,7 @@ class DefaultIntentProcessorFactory @Inject constructor(
                 bookmarkArticleByIdUseCase = bookmarkArticleByIdUseCase,
                 getArticlesUseCase = getArticlesUseCase,
                 isArticleBookmarkedUseCase = isArticleBookmarkedUseCase,
+                crashlyticsWrapper = crashlyticsWrapper,
             )
         }
     }


### PR DESCRIPTION
- `CrashlyticsWrapper` is created to be a common interface for any crashlytics service.
- `FirebaseCrashlyticsProvider` is created to handle Firebase implementation details.
- `FetchArticlesIntentProcessor`, `BookmarkArticleIntentProcessor`, and `FetchArticleIntentProcessor` now record exceptions with `CrashlyticsWrapper`.
- Added `className` and `action` to `CrashlyticsWrapper.Params`.

CLOSES #36