### PR TITLE
feat(audio-player): Implement audio player controls

### DIFF
--- a/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/theme/KIcon.kt
+++ b/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/theme/KIcon.kt
@@ -9,9 +9,11 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material.icons.rounded.Forward10
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Podcasts
+import androidx.compose.material.icons.rounded.Replay10
 
 object KIcon {
     val ArrowBack = Icons.AutoMirrored.Rounded.ArrowBack
@@ -25,4 +27,6 @@ object KIcon {
     val PlayArrow = Icons.Rounded.PlayArrow
     val Pause = Icons.Rounded.Pause
     val Bookmark = Icons.Rounded.Bookmark
+    val Replay10 = Icons.Rounded.Replay10
+    val Forward10 = Icons.Rounded.Forward10
 }

--- a/feature/audioplayer/build.gradle.kts
+++ b/feature/audioplayer/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.ui.compose)
     implementation(libs.androidx.media3.session)
+    implementation(projects.core.app)
 }

--- a/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerController.kt
+++ b/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerController.kt
@@ -1,0 +1,213 @@
+package com.kesicollection.feature.audioplayer
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.core.content.ContextCompat
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.google.common.util.concurrent.ListenableFuture
+import com.kesicollection.core.app.qualifiers.KesiAndroidApiUrl
+import com.kesicollection.feature.audioplayer.di.AudioPlayerDefaultDispatcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.concurrent.ExecutionException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class DomainMediaItem(
+    val id: String,                 // Your app's unique ID for this item
+    val fileName: String,          // URI as a string (URL, content URI, etc.)
+    val title: String? = null,
+    val artist: String? = null,
+    val albumTitle: String? = null,
+    val artworkUri: String? = null,         // Artwork URI as a string
+    val durationMs: Long? = null,   // Optional: if known beforehand
+    val userExtras: Map<String, String>? = null // For any other custom data your app needs
+)
+
+/**
+ * Represents the different UI-relevant states the player can be in.
+ */
+sealed class PlayerStateUi {
+    data object Idle : PlayerStateUi()
+    data object Buffering : PlayerStateUi()
+    data object Ready : PlayerStateUi()
+    data object Playing : PlayerStateUi()
+    data object Paused : PlayerStateUi()
+    data object Ended : PlayerStateUi()
+    data class Error(val message: String) : PlayerStateUi()
+}
+
+interface AudioPlayerController {
+    fun prepareAndPlay(mediaItem: DomainMediaItem)
+    fun play()
+    fun pause()
+    fun seekTo(positionMs: Long)
+    fun skipToNext()
+    fun skipToPrevious()
+    fun setShuffleModeEnabled(enabled: Boolean)
+//    fun setRepeatMode(repeatMode: Int)
+
+    // --- State Flows ---
+    /** Emits the current high-level state of the player (e.g., Idle, Playing, Paused). */
+    val playerState: StateFlow<PlayerStateUi>
+
+    /** Emits the current playback position in milliseconds. */
+    val currentPositionMs: StateFlow<Float>
+
+    // --- Lifecycle ---
+    fun initialize() // Could take SessionToken if built on demand
+    fun release()
+}
+
+@Singleton
+class Media3AudioPlayerController @Inject constructor(
+    @AudioPlayerDefaultDispatcher dispatcher: CoroutineDispatcher,
+    @ApplicationContext private val context: Context,
+    @KesiAndroidApiUrl private val kesiAndroidApiUrl: String,
+) : AudioPlayerController, Player.Listener {
+
+    private val coroutineScope = CoroutineScope(dispatcher + SupervisorJob())
+    private var mediaController: MediaController? = null
+    private var controllerFuture: ListenableFuture<MediaController>? = null
+    private var progressUpdateJob: Job? = null
+    private val componentName: ComponentName by lazy {
+        ComponentName(context, AudioPlayerService::class.java)
+    }
+
+    private val _playerState = MutableStateFlow<PlayerStateUi>(PlayerStateUi.Idle)
+    override val playerState: StateFlow<PlayerStateUi> = _playerState.asStateFlow()
+    private val _currentPositionMs = MutableStateFlow(0f)
+    override val currentPositionMs: StateFlow<Float> = _currentPositionMs.asStateFlow()
+
+    override fun initialize() {
+        if (mediaController != null || controllerFuture != null) return // Already initialized or initializing
+        val sessionToken = SessionToken(context, componentName)
+        controllerFuture = MediaController.Builder(context, sessionToken).buildAsync()
+        controllerFuture?.addListener({
+            try {
+                controllerFuture?.get()?.run {
+                    mediaController = this
+                    addListener(this@Media3AudioPlayerController)
+                    _playerState.value = PlayerStateUi.Ready
+                } ?: with(_playerState) {
+                    value = PlayerStateUi.Error(
+                        "Failed to connect to MediaController: Controller is null."
+                    )
+                }
+            } catch (e: ExecutionException) {
+                _playerState.value =
+                    PlayerStateUi.Error("Connection error: ${e.cause?.message ?: e.message}")
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                _playerState.value = PlayerStateUi.Error("Connection interrupted.")
+            } catch (e: Exception) {
+                _playerState.value =
+                    PlayerStateUi.Error("An unexpected error occurred during connection: ${e.message}")
+            }
+        }, ContextCompat.getMainExecutor(context))
+    }
+
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        if (isPlaying) {
+            _playerState.value = PlayerStateUi.Playing
+            startProgressUpdates()
+        } else {
+            // Determine if paused due to end of media or user action/buffering
+            if (mediaController?.playbackState == Player.STATE_ENDED) {
+                _playerState.value = PlayerStateUi.Ended
+            } else if (mediaController?.playbackState != Player.STATE_BUFFERING) {
+                _playerState.value = PlayerStateUi.Paused
+            }
+            // If it's just buffering, onPlaybackStateChanged will set PlayerStateUi.Buffering
+            stopProgressUpdates()
+        }
+    }
+
+    override fun release() {
+        stopProgressUpdates()
+        mediaController?.removeListener(this)
+        controllerFuture?.let {
+            if (!it.isDone && !it.isCancelled) {
+                // Attempt to cancel if connection was in progress
+                it.cancel(true)
+            }
+            MediaController.releaseFuture(it)
+        }
+        mediaController = null
+        controllerFuture = null
+    }
+
+    override fun prepareAndPlay(mediaItem: DomainMediaItem) {
+        if (mediaController?.playbackState != Player.EVENT_IS_LOADING_CHANGED
+            || mediaController?.currentMediaItem?.mediaId != mediaItem.id) {
+            mediaController?.apply {
+                setMediaItem(
+                    MediaItem.Builder()
+                        .setMediaId(mediaItem.id)
+                        .setUri("${kesiAndroidApiUrl}podcasts/${mediaItem.fileName}")
+                        .build()
+                )
+                prepare()
+                play()
+            }
+        }
+    }
+
+    override fun play() {
+        mediaController?.play()
+    }
+
+    override fun pause() {
+        mediaController?.pause()
+    }
+
+    override fun seekTo(positionMs: Long) {
+        val result = (mediaController?.currentPosition?.toFloat() ?: 0f) + positionMs.toFloat()
+        mediaController?.seekTo(result.toLong().coerceAtLeast(0))
+        _currentPositionMs.value = result / (mediaController?.duration?.toFloat() ?: 1f)
+    }
+
+    override fun skipToNext() {
+        mediaController?.seekToNextMediaItem()
+    }
+
+    override fun skipToPrevious() {
+        mediaController?.seekToPreviousMediaItem()
+    }
+
+    override fun setShuffleModeEnabled(enabled: Boolean) {
+        mediaController?.shuffleModeEnabled = enabled
+    }
+
+    private fun startProgressUpdates() {
+        progressUpdateJob?.cancel()
+        progressUpdateJob = coroutineScope.launch {
+            while (true) {
+                mediaController?.let {
+                    if (it.isPlaying) {
+                        val duration = if (it.duration < 0) 1L else it.duration
+                        val progress = it.currentPosition.toFloat() / duration.toFloat()
+                        _currentPositionMs.value = progress
+                    }
+                }
+                delay(250L)
+            }
+        }
+    }
+
+    private fun stopProgressUpdates() {
+        progressUpdateJob?.cancel()
+        progressUpdateJob = null
+    }
+}

--- a/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerScreen.kt
+++ b/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerScreen.kt
@@ -1,11 +1,11 @@
 package com.kesicollection.feature.audioplayer
 
-import android.content.ComponentName
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,50 +22,25 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.media3.common.MediaItem
-import androidx.media3.session.MediaController
-import androidx.media3.session.SessionToken
-import com.google.common.util.concurrent.MoreExecutors
 import com.kesicollection.core.uisystem.LocalApp
 import com.kesicollection.core.uisystem.component.KCard
 import com.kesicollection.core.uisystem.theme.KIcon
 import com.kesicollection.core.uisystem.theme.KesiTheme
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-
-//TODO: Move it to an inf or shared module.
-fun <T> propertyChangeFlow(propertyProvider: () -> T): Flow<T> = flow {
-    var previousValue: T = propertyProvider() // Store the initial value
-    emit(previousValue) // Emit the initial value
-
-    while (true) {
-        delay(100) // Check every 100 milliseconds
-        val currentValue = propertyProvider()
-        if (currentValue != previousValue) {
-            emit(currentValue) // Emit only if the value has changed
-            previousValue = currentValue
-        }
-    }
-}
 
 @Composable
 fun AudioPlayerScreen(
@@ -75,12 +50,8 @@ fun AudioPlayerScreen(
     modifier: Modifier = Modifier,
     viewModel: AudioPlayerViewModel = hiltViewModel()
 ) {
-
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    var mediaController: MediaController? by remember { mutableStateOf(null) }
     var progress by remember { mutableFloatStateOf(0f) }
-    var isPlaying by remember { mutableStateOf(false) }
 
     val analytics = LocalApp.current.analytics
     SideEffect {
@@ -92,52 +63,15 @@ fun AudioPlayerScreen(
         )
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.sendIntent(Intent.InitScreen(title))
-    }
-
-    LaunchedEffect(Unit) {
-        val sessionToken = SessionToken(
-            context, ComponentName(context, AudioPlayerService::class.java)
-        )
-        val controllerFuture = MediaController.Builder(
-            context, sessionToken
-        ).buildAsync()
-
-        controllerFuture.addListener(
-            { mediaController = controllerFuture.get() },
-            MoreExecutors.directExecutor()
-        )
-    }
-
-    LaunchedEffect(mediaController) {
-        mediaController?.let {
-            it.setMediaItem(MediaItem.fromUri("https://raw.githubusercontent.com/kesicollection/kesi-android-api-data/refs/heads/v1/podcasts/$fileName"))
-            it.prepare()
-            it.play()
+    LaunchedEffect(uiState.playerState) {
+        if (uiState.playerState == PlayerStateUi.Ready) {
+            viewModel.sendIntent(Intent.InitScreen(title, fileName))
         }
     }
 
     LaunchedEffect(Unit) {
-        propertyChangeFlow { mediaController?.currentPosition?.toFloat() ?: 1f }
-            .collect { newValue ->
-                val duration = mediaController?.let {
-                    if (it.duration < 0) 1f else it.duration
-                }?.toFloat() ?: 1f
-                progress = newValue / duration
-            }
-    }
-
-    LaunchedEffect(Unit) {
-        propertyChangeFlow { mediaController?.isPlaying ?: false }
-            .collect { newValue ->
-                isPlaying = newValue
-            }
-    }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            mediaController?.release()
+        viewModel.currentPositionMs.collect {
+            progress = it
         }
     }
 
@@ -145,19 +79,19 @@ fun AudioPlayerScreen(
         uiState = uiState,
         onNavigateUp = onNavigateUp,
         modifier = modifier,
-        progress = {
-            progress
-        },
-        isPlaying = { isPlaying },
+        progress = { progress },
+        isPlaying = { uiState.playerState == PlayerStateUi.Playing },
+        onReply10Click = { viewModel.sendIntent(Intent.SeekTo(-10f * 1000)) },
+        onForward10Click = { viewModel.sendIntent(Intent.SeekTo(10f * 1000)) },
         onPlayPauseClick = {
-            if (isPlaying) {
+            if (uiState.playerState == PlayerStateUi.Playing) {
                 analytics.logEvent(
                     analytics.event.pauseAudioPlayer, mapOf(
                         analytics.param.itemId to fileName,
                         analytics.param.contentType to "podcast"
                     )
                 )
-                mediaController?.pause()
+                viewModel.sendIntent(Intent.PauseAudio)
             } else {
                 analytics.logEvent(
                     analytics.event.playAudioPlayer, mapOf(
@@ -165,7 +99,7 @@ fun AudioPlayerScreen(
                         analytics.param.contentType to "podcast"
                     )
                 )
-                mediaController?.play()
+                viewModel.sendIntent(Intent.PlayAudio)
             }
         }
     )
@@ -180,6 +114,8 @@ internal fun AudioPlayerScreen(
     progress: () -> Float,
     isPlaying: () -> Boolean,
     onPlayPauseClick: () -> Unit,
+    onReply10Click: () -> Unit,
+    onForward10Click: () -> Unit,
 ) {
     val safeContent = WindowInsets.Companion.safeContent.asPaddingValues()
     Column(
@@ -229,22 +165,44 @@ internal fun AudioPlayerScreen(
 
             LinearProgressIndicator(progress = progress)
         }
-        Box(
-            modifier = Modifier
-                .padding(bottom = safeContent.calculateBottomPadding() + 16.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.onBackground)
-                .size(76.dp)
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                if (isPlaying()) KIcon.Pause else KIcon.PlayArrow,
+                KIcon.Replay10,
                 null,
                 modifier = Modifier
-                    .size(32.dp)
-                    .align(Alignment.Center)
-                    .clickable { onPlayPauseClick() },
-                tint = MaterialTheme.colorScheme.background
+                    .clip(CircleShape)
+                    .size(56.dp)
+                    .clickable { onReply10Click() }
             )
+            Box(
+                modifier = Modifier
+                    .padding(bottom = safeContent.calculateBottomPadding() + 16.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.onBackground)
+                    .size(76.dp)
+            ) {
+                Icon(
+                    if (isPlaying()) KIcon.Pause else KIcon.PlayArrow,
+                    null,
+                    modifier = Modifier
+                        .size(32.dp)
+                        .align(Alignment.Center)
+                        .clickable { onPlayPauseClick() },
+                    tint = MaterialTheme.colorScheme.background
+                )
+            }
+
+            Icon(
+                KIcon.Forward10,
+                null,
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .size(56.dp)
+                    .clickable { onForward10Click() })
+
         }
     }
 }
@@ -256,7 +214,6 @@ private fun AudioPlayerPreview() {
         modifier = Modifier.fillMaxSize(),
         uiAudioPlayerState = UiAudioPlayerState(
             title = "This is the title of the podcast, cool ah?",
-            isPlaying = true
         )
     )
 }
@@ -274,6 +231,8 @@ private fun AudioPlayerExample(
             progress = { 0f },
             isPlaying = { true },
             onPlayPauseClick = {},
+            onForward10Click = {},
+            onReply10Click = {}
         )
     }
 }

--- a/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerViewModel.kt
+++ b/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/AudioPlayerViewModel.kt
@@ -2,49 +2,85 @@ package com.kesicollection.feature.audioplayer
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kesicollection.feature.audioplayer.di.AudioPlayerDefaultDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class AudioPlayerViewModel @Inject constructor() : ViewModel() {
+class AudioPlayerViewModel @Inject constructor(
+    private val audioPlayerController: AudioPlayerController,
+    @AudioPlayerDefaultDispatcher private val dispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    val currentPositionMs = audioPlayerController.currentPositionMs
 
     private val _uiState = MutableStateFlow(initialState)
-    val uiState = _uiState.asStateFlow()
+    val uiState = combine(
+        _uiState,
+        audioPlayerController.playerState,
+    ) { uiState, playerState ->
+        uiState.copy(
+            playerState = playerState,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000L),
+        initialState
+    )
 
     private val intent = MutableSharedFlow<Intent>()
 
     init {
-        viewModelScope.launch {
+        audioPlayerController.initialize()
+        viewModelScope.launch(dispatcher) {
             intent.collect {
                 when (it) {
                     Intent.PlayAudio -> playAudio()
                     Intent.PauseAudio -> pauseAudio()
                     is Intent.InitScreen -> initScreen(it)
+                    is Intent.SeekTo -> seekTo(it.distance)
                 }
             }
         }
     }
 
+    private fun seekTo(distance: Float) {
+        audioPlayerController.seekTo(distance.toLong())
+    }
+
+    /**
+     * Called when the ViewModel is about to be destroyed.
+     * Releases the player controller and its resources.
+     */
+    override fun onCleared() {
+        super.onCleared()
+        audioPlayerController.release()
+    }
+
     private fun initScreen(data: Intent.InitScreen) {
+        audioPlayerController.prepareAndPlay(DomainMediaItem(id = data.title, fileName = data.fileName))
         reducer { copy(title = data.title) }
     }
 
     fun sendIntent(action: Intent) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcher) {
             intent.emit(action)
         }
     }
 
     private fun pauseAudio() {
-        reducer { copy(isPlaying = false) }
+        audioPlayerController.pause()
     }
 
     private fun playAudio() {
-        reducer { copy(isPlaying = true) }
+        audioPlayerController.play()
     }
 
     private fun reducer(reducer: Reducer) {

--- a/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/UiState.kt
+++ b/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/UiState.kt
@@ -5,15 +5,20 @@ import com.kesicollection.core.uisystem.ErrorState
 val initialState = UiAudioPlayerState()
 
 data class UiAudioPlayerState(
+    val playerState: PlayerStateUi = PlayerStateUi.Idle,
     val title: String = "",
-    val isPlaying: Boolean = false,
     val error: ErrorState<AudioPlayerErrors>? = null
 )
 
 sealed interface Intent {
-    data class InitScreen(val title: String) : Intent
+    data class InitScreen(
+        val title: String,
+        val fileName: String
+    ) : Intent
+
     data object PlayAudio : Intent
     data object PauseAudio : Intent
+    data class SeekTo(val distance: Float) : Intent
 }
 
 typealias Reducer = UiAudioPlayerState.() -> UiAudioPlayerState

--- a/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/di/AudioPlayerModule.kt
+++ b/feature/audioplayer/src/main/kotlin/com/kesicollection/feature/audioplayer/di/AudioPlayerModule.kt
@@ -1,0 +1,35 @@
+package com.kesicollection.feature.audioplayer.di
+
+import com.kesicollection.feature.audioplayer.AudioPlayerController
+import com.kesicollection.feature.audioplayer.Media3AudioPlayerController
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AudioPlayerDefaultDispatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AudioPlayerModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAudioPlayerController(
+        media3AudioPlayerController: Media3AudioPlayerController
+    ): AudioPlayerController
+
+    companion object {
+
+        @Provides
+        @AudioPlayerDefaultDispatcher
+        fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Main
+    }
+}


### PR DESCRIPTION
This commit introduces the functionality for controlling audio playback within the app's audio player feature. It includes the implementation of play/pause, seek forward, and seek backward actions.

- Added `Forward10` and `Replay10` icons to `KIcon`.
- Created `AudioPlayerController` interface and `Media3AudioPlayerController` implementation to manage Media3 player state and commands.
- Implemented play, pause, and seek functionality in `Media3AudioPlayerController`.
- Integrated `AudioPlayerController` into `AudioPlayerViewModel`.
- Updated `AudioPlayerViewModel` to handle player state changes and dispatch commands.
- Added seek actions (`SeekTo`) to the `Intent` sealed class.
- Connected UI buttons for play/pause, replay, and forward to the `AudioPlayerViewModel` intents.
- Added necessary dependencies for `androidx.media3.session` and `core.app` to the `audioplayer` module.

CLOSES #40