### PR TITLE
feat(navigation): Implement navigation between Discover, Articles, an…

### DIFF
--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/AppNavigation.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/AppNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.kesicollection.articles.ArticlesRoute
 import com.kesicollection.articles.articles
+import com.kesicollection.articles.navigateToArticles
 import com.kesicollection.core.app.AppRoute
 import com.kesicollection.core.uisystem.theme.KesiTheme
 import com.kesicollection.feature.article.ArticleRoute
@@ -19,17 +20,13 @@ import com.kesicollection.feature.audioplayer.navigateToAudiPlayer
 import com.kesicollection.feature.discover.discover
 
 /**
- * Defines the main navigation structure of the application.
+ * Defines the main navigation structure of the Kesi application.
  *
- * This composable sets up the navigation host using [NavHost] and
- * defines the available destinations. It uses a [NavHostController] to
- * manage the navigation state and transitions between different parts of
- * the app.
+ * This composable sets up the [NavHost] and defines the available destinations.
+ * It utilizes a [NavHostController] to manage navigation state and transitions.
  *
  * @sample com.kesicollection.kesiandroid.ExampleAppNavigation
- *
- * @param navController The [NavHostController] responsible for managing
- *                      the navigation graph and state.
+ * @param navController The [NavHostController] managing the navigation graph and state.
  * @param startDestination The [AppRoute] representing the initial
  *                         destination to navigate to when the app starts.
  * @param modifier Modifier to be applied to the navigation host.
@@ -44,11 +41,16 @@ fun AppNavigation(
         navController = navController,
         startDestination = startDestination
     ) {
-        discover(modifier = modifier)
-
-        articles(modifier = modifier, onArticleClick = {
-            navController.navigateToArticle(ArticleRoute(it))
-        })
+        discover(
+            modifier = modifier,
+            onArticleClick = navController::onArticleClick,
+            onSeeAllClick = navController::onSeeAllClick,
+        )
+        articles(
+            modifier = modifier,
+            onArticleClick = navController::onArticleClick,
+            onNavigateUp = navController::onNavigateUp,
+        )
         article(
             modifier = modifier,
             onNavigateUp = navController::onNavigateUp,
@@ -66,12 +68,10 @@ fun AppNavigation(
 }
 
 /**
- * Navigates up in the navigation hierarchy.
+ * Navigates up in the navigation stack.
  *
- * This function provides a concise way to perform a "navigate up" action
- * using the `NavController`. It essentially calls [NavController.popBackStack]
- * which attempts to pop the current destination from the back stack and
- * navigate to the previous destination.
+ * This extension function calls [NavController.popBackStack] to remove the
+ * current destination from the back stack and navigate to the previous one.
  *
  * If there's no previous destination on the back stack, this will effectively do nothing.
  *
@@ -81,6 +81,32 @@ private fun NavController.onNavigateUp() {
     popBackStack()
 }
 
+/**
+ * Navigates to the article detail screen for the given article ID.
+ *
+ * This extension function uses [navigateToArticle] with an [ArticleRoute]
+ * to transition to the specific article's content.
+ *
+ * @receiver [NavController] The navigation controller that manages the navigation graph.
+ * @param articleId The unique identifier of the article to display.
+ */
+private fun NavController.onArticleClick(articleId: String) {
+    navigateToArticle(ArticleRoute(articleId))
+}
+
+/**
+ * Navigates to the "See All" articles screen.
+ *
+ * This extension function utilizes [navigateToArticles] to display a comprehensive
+ * list of available articles.
+ *
+ * @receiver [NavController] The navigation controller that manages the navigation graph.
+ */
+private fun NavController.onSeeAllClick() {
+    navigateToArticles()
+}
+
+/** Example composable demonstrating the usage of [AppNavigation]. */
 @Composable
 private fun ExampleAppNavigation(modifier: Modifier) {
     KesiTheme {

--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/MainActivity.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/MainActivity.kt
@@ -16,7 +16,7 @@ import com.kesicollection.core.app.AppManager
 import com.kesicollection.core.uisystem.LocalApp
 import com.kesicollection.core.uisystem.LocalImageLoader
 import com.kesicollection.core.uisystem.theme.KesiTheme
-import com.kesicollection.feature.discover.Discover
+import com.kesicollection.feature.discover.DiscoverRoute
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -50,7 +50,7 @@ class MainActivity : ComponentActivity() {
                     KesiTheme {
                         AppNavigation(
                             navController = rememberNavController(),
-                            startDestination = Discover,
+                            startDestination = DiscoverRoute,
                             modifier = Modifier.fillMaxSize()
                         )
                     }

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.CompositionLocalProvider
@@ -22,6 +25,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -44,6 +48,7 @@ import com.kesicollection.core.uisystem.LocalImageLoader
 import com.kesicollection.core.uisystem.component.KAdView
 import com.kesicollection.core.uisystem.component.KScaffold
 import com.kesicollection.core.uisystem.component.ShowError
+import com.kesicollection.core.uisystem.theme.KIcon
 import com.kesicollection.core.uisystem.theme.KesiTheme
 import com.kesicollection.feature.articles.R
 import dagger.hilt.EntryPoints
@@ -67,6 +72,7 @@ import dagger.hilt.EntryPoints
 fun ArticlesScreen(
     modifier: Modifier = Modifier,
     onArticleClick: (articleId: String) -> Unit,
+    onNavigateUp: () -> Unit,
     viewModel: ArticlesViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -92,6 +98,7 @@ fun ArticlesScreen(
 
     ArticlesScreen(
         modifier = modifier,
+        onNavigateUp = onNavigateUp,
         onArticleClick = onArticleClick,
         onBookmarkClick = {
             analytics.logEvent(
@@ -140,14 +147,28 @@ internal fun ArticlesScreen(
     onArticleClick: (articleId: String) -> Unit,
     onBookmarkClick: (Intent.BookmarkClicked) -> Unit,
     onTryAgain: (Intent.FetchArticles) -> Unit,
+    onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     KScaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            TopAppBar(title = {
-                Text(stringResource(R.string.feature_articles_topbar_title))
-            })
+            TopAppBar(
+                colors = TopAppBarDefaults.topAppBarColors(),
+                title = {
+                    Text(
+                        stringResource(R.string.feature_articles_topbar_title),
+                        style = MaterialTheme.typography.headlineLarge
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onNavigateUp) {
+                        Icon(imageVector = KIcon.ArrowBack, null)
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
         }
     ) { innerPadding ->
         uiState.error?.let {
@@ -257,6 +278,7 @@ private fun ArticlesScreenExample(
                     modifier = modifier,
                     uiState = uiState,
                     adUnitId = "",
+                    onNavigateUp = {},
                     onArticleClick = {},
                     onBookmarkClick = {},
                     onTryAgain = {}

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/Navigation.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/Navigation.kt
@@ -1,19 +1,55 @@
 package com.kesicollection.articles
 
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.kesicollection.core.app.AppRoute
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents the route for the articles screen.
+ * This object is serializable and extends [AppRoute].
+ */
 @Serializable
 data object ArticlesRoute : AppRoute
 
+/**
+ * Navigates to the articles screen.
+ *
+ * This extension function on [NavController] simplifies the navigation process
+ * to the [ArticlesRoute].
+ *
+ * @param route The [ArticlesRoute] to navigate to. Defaults to `ArticlesRoute`.
+ * @param navOptions Optional [NavOptions] to configure the navigation.
+ */
+fun NavController.navigateToArticles(
+    route: ArticlesRoute = ArticlesRoute, navOptions: NavOptions? = null
+) = navigate(route, navOptions)
+
+/**
+ * Defines the articles screen within the navigation graph.
+ *
+ * This extension function on [NavGraphBuilder] sets up the composable destination
+ * for the [ArticlesRoute].
+ *
+ * @param modifier Optional [Modifier] to be applied to the [ArticlesScreen].
+ * @param onArticleClick A lambda function to be invoked when an article is clicked.
+ *                       It takes the article ID as a [String] parameter.
+ * @param onNavigateUp A lambda function to be invoked for navigating up from the screen.
+ */
 fun NavGraphBuilder.articles(
     modifier: Modifier = Modifier,
     onArticleClick: (id: String) -> Unit,
+    onNavigateUp: () -> Unit,
 ) {
+    // Defines the composable for the ArticlesRoute.
     composable<ArticlesRoute> {
-        ArticlesScreen(modifier = modifier, onArticleClick)
+        ArticlesScreen(
+            modifier = modifier,
+            onArticleClick = onArticleClick,
+            onNavigateUp = onNavigateUp,
+        )
     }
 }

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -19,6 +18,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kesicollection.core.model.ContentType
 import com.kesicollection.core.model.ErrorState
+import com.kesicollection.core.uisystem.component.KScaffold
 import com.kesicollection.core.uisystem.theme.KesiTheme
 import com.kesicollection.feature.discover.component.LoadingDiscover
 import com.kesicollection.feature.discover.component.featuredContentSection
@@ -60,12 +60,11 @@ private fun DiscoverScreen(
     modifier: Modifier = Modifier,
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-    Scaffold(
+    KScaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             CenterAlignedTopAppBar(
-                colors = TopAppBarDefaults.topAppBarColors()
-                    .copy(containerColor = MaterialTheme.colorScheme.background),
+                colors = TopAppBarDefaults.topAppBarColors(),
                 title = {
                     Text("Kesi Android", style = MaterialTheme.typography.titleMedium)
                 },

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/Navigation.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/Navigation.kt
@@ -1,22 +1,64 @@
 package com.kesicollection.feature.discover
 
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.kesicollection.core.app.AppRoute
+import com.kesicollection.core.model.ContentType
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents the route for the Discover screen.
+ * This object is used for navigation purposes within the app.
+ */
 @Serializable
-data object Discover : AppRoute
+data object DiscoverRoute : AppRoute
 
+/**
+ * Defines the Discover screen within the navigation graph.
+ *
+ * This function sets up the composable for the Discover screen, handling navigation
+ * and interactions such as clicking on an article or a "See All" button.
+ *
+ * @param modifier The modifier to be applied to the Discover screen.
+ * @param onArticleClick A lambda function to be invoked when an article is clicked.
+ *                       It receives the ID of the clicked article as a [String].
+ * @param onSeeAllClick A lambda function to be invoked when a "See All" button for a category is clicked.
+ */
 fun NavGraphBuilder.discover(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onArticleClick: (articleId: String) -> Unit,
+    onSeeAllClick: () -> Unit,
 ) {
-    composable<Discover> {
+    composable<DiscoverRoute> {
+        // Remember the content click handler to avoid recomposition when the lambda doesn't change.
+        // This handler determines the action based on the type of content clicked.
+        val rememberedOnContentClick = remember<(UIContent) -> Unit> {
+            {
+                when (it.type) {
+                    ContentType.Article -> onArticleClick(it.id)
+                    ContentType.Podcast -> {}
+                    ContentType.Video -> {}
+                    ContentType.Demo -> {}
+                }
+            }
+        }
+
+        // Remember the "See All" click handler.
+        // This is invoked when the user wants to view all content within a specific category.
+        val rememberedOnSeeAllClick = remember<(UICategory) -> Unit> {
+            {
+                // For now we will simple show all the articles with no filter applied.
+                // The specific category `it` is passed but currently not used to filter.
+                onSeeAllClick()
+            }
+        }
+
         DiscoverScreen(
             modifier = modifier,
-            onSeeAllClick = {},
-            onContentClick = {}
+            onSeeAllClick = rememberedOnSeeAllClick,
+            onContentClick = rememberedOnContentClick
         )
     }
 }


### PR DESCRIPTION
…d Article screens

This commit introduces navigation functionality between the Discover, Articles, and Article detail screens.

- Updated `AppNavigation` to handle navigation actions:
    - `onArticleClick` from Discover and Articles screens navigates to the `ArticleRoute`.
    - `onSeeAllClick` from Discover screen navigates to `ArticlesRoute`.
    - `onNavigateUp` from Articles and Article screens pops the back stack.
- Modified `ArticlesScreen`:
    - Added a `TopAppBar` with a title and a back navigation icon.
    - Implemented `onNavigateUp` to handle back navigation.
- Updated `ArticlesRoute` and `DiscoverRoute` to be `data object`s.
- Enhanced `articles` and `discover` navigation graph builders to accept and pass navigation callbacks.
- Renamed `Discover` route to `DiscoverRoute` for consistency.
- Updated `MainActivity` to use `DiscoverRoute` as the start destination.
- Refined KDoc comments in `AppNavigation.kt` and `Navigation.kt` files for clarity.
- Used `KScaffold` in `DiscoverScreen` for consistency.

Closes #50 