### PR TITLE
feat(discover): Implement analytics and error reporting

### DIFF
--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseEventProvider.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseEventProvider.kt
@@ -29,4 +29,6 @@ object FirebaseEventProvider: AnalyticsWrapper.Event {
         get() = "pause_audio_player"
     override val adImpression: String
         get() = FirebaseAnalytics.Event.AD_IMPRESSION
+    override val onSeeAll: String
+        get() = "see_all"
 }

--- a/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseParamProvider.kt
+++ b/app/src/main/kotlin/com/kesicollection/kesiandroid/analytics/FirebaseParamProvider.kt
@@ -24,4 +24,6 @@ object FirebaseParamProvider : AnalyticsWrapper.Param {
         get() = FirebaseAnalytics.Param.ITEM_NAME
     override val contentType: String
         get() = FirebaseAnalytics.Param.CONTENT_TYPE
+    override val contentEmphasis: String
+        get() = "content_emphasis"
 }

--- a/core/app/src/main/kotlin/com/kesicollection/core/app/AnalyticsWrapper.kt
+++ b/core/app/src/main/kotlin/com/kesicollection/core/app/AnalyticsWrapper.kt
@@ -48,6 +48,7 @@ interface AnalyticsWrapper {
         val forward10AudioPlayer: String
         val pauseAudioPlayer: String
         val adImpression: String
+        val onSeeAll: String
     }
 
     /**
@@ -62,6 +63,7 @@ interface AnalyticsWrapper {
         val itemId: String
         val itemName: String
         val contentType: String
+        val contentEmphasis: String
     }
 
     /**

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/intentprocessor/FetchFeatureItemsIntentProcessor.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/intentprocessor/FetchFeatureItemsIntentProcessor.kt
@@ -1,5 +1,6 @@
 package com.kesicollection.feature.discover.intentprocessor
 
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.app.IntentProcessor
 import com.kesicollection.core.app.Reducer
 import com.kesicollection.core.model.ErrorState
@@ -9,6 +10,7 @@ import com.kesicollection.feature.discover.UiState
 import com.kesicollection.feature.discover.asDiscoverContent
 import com.kesicollection.feature.discover.contentSample
 import kotlinx.coroutines.delay
+import java.util.concurrent.CancellationException
 
 /**
  * Processes the intent to fetch feature items for the Discover screen.
@@ -21,14 +23,22 @@ import kotlinx.coroutines.delay
  * @property getDiscoverContentUseCase The use case responsible for fetching discover content.
  */
 class FetchFeatureItemsIntentProcessor(
-    val getDiscoverContentUseCase: GetDiscoverContentUseCase
+    val getDiscoverContentUseCase: GetDiscoverContentUseCase,
+    val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessor<UiState> {
     override suspend fun processIntent(reducer: (Reducer<UiState>) -> Unit) {
         try {
             val result = getDiscoverContentUseCase().getOrThrow().asDiscoverContent()
             reducer { result }
+        } catch (_: CancellationException) {
+            /* no-op */
         } catch (e: Exception) {
             reducer { UiState.Error(ErrorState(DiscoverErrors.GenericError, e.message)) }
+            crashlyticsWrapper.recordException(e, mapOf(
+                crashlyticsWrapper.params.screenName to "DiscoverScreen",
+                crashlyticsWrapper.params.className to "FetchFeatureItemsIntentProcessor",
+                crashlyticsWrapper.params.action to "fetch",
+            ))
         }
     }
 

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/intentprocessor/IntentProcessorFactory.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/intentprocessor/IntentProcessorFactory.kt
@@ -1,5 +1,6 @@
 package com.kesicollection.feature.discover.intentprocessor
 
+import com.kesicollection.core.app.CrashlyticsWrapper
 import com.kesicollection.core.app.IntentProcessor
 import com.kesicollection.core.app.IntentProcessorFactory
 import com.kesicollection.data.usecase.GetDiscoverContentUseCase
@@ -19,12 +20,14 @@ import javax.inject.Singleton
  */
 @Singleton
 class DefaultIntentProcessorFactory @Inject constructor(
-    private val getDiscoverContentUseCase: GetDiscoverContentUseCase
+    private val getDiscoverContentUseCase: GetDiscoverContentUseCase,
+    private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessorFactory<UiState, Intent> {
     override fun create(intent: Intent): IntentProcessor<UiState> =
         when (intent) {
             Intent.FetchFeatureItems -> FetchFeatureItemsIntentProcessor(
-                getDiscoverContentUseCase = getDiscoverContentUseCase
+                getDiscoverContentUseCase = getDiscoverContentUseCase,
+                crashlyticsWrapper = crashlyticsWrapper,
             )
         }
 }


### PR DESCRIPTION
This commit introduces analytics tracking and error reporting to the Discover screen.

- Added `onSeeAll` event to `FirebaseEventProvider`.
- Added `contentEmphasis` parameter to `FirebaseParamProvider`.
- Integrated `CrashlyticsWrapper` into `FetchFeatureItemsIntentProcessor` to record exceptions during data fetching.
- Implemented analytics logging for:
    - Screen views (`DiscoverScreen`).
    - "Try Again" button clicks.
    - Content item selections, including an emphasis parameter (`featured` or `promoted`).
    - "See All" button clicks for categories.
- Updated `ExampleDiscoverScreen` to use `CompositionLocalProvider` for `LocalAsyncImagePreviewHandler` and `LocalImageLoader` to enable image previews.

#CLOSES #57