### PR TITLE
fix(articles): Prevent multiple API calls on screen rotation

### DIFF
--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/ArticlesScreen.kt
@@ -93,7 +93,9 @@ fun ArticlesScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.sendIntent(Intent.FetchArticles)
+        if (uiState.isLoading && uiState.articles.isEmpty()) {
+            viewModel.sendIntent(Intent.FetchArticles)
+        }
     }
 
     ArticlesScreen(

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/UiState.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/UiState.kt
@@ -14,7 +14,7 @@ val initialState = UiArticlesState()
  */
 data class UiArticlesState(
     val articles: List<UiArticle> = emptyList(),
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val error: ErrorState<ArticlesErrors>? = null
 )
 

--- a/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/FetchArticlesIntentProcessor.kt
+++ b/feature/articles/src/main/kotlin/com/kesicollection/articles/intentprocessor/FetchArticlesIntentProcessor.kt
@@ -51,7 +51,7 @@ class FetchArticlesIntentProcessor(
     private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessor<UiArticlesState> {
     override suspend fun processIntent(reducer: (Reducer<UiArticlesState>) -> Unit) {
-        reducer { copy(isLoading = true, error = null) }
+        reducer { copy(isLoading = true, error = null, articles = emptyList()) }
         try {
             val articles = getArticlesUseCase().getOrThrow().map {
                 it.asUiArticle().copy(isBookmarked = isArticleBookmarkedUseCase(it.id))


### PR DESCRIPTION
- Modified `ArticlesScreen` to fetch articles only if `isLoading` is true and `articles` list is empty in the `LaunchedEffect`.
- Changed the initial value of `isLoading` in `UiArticlesState` to `true`.
- Updated `FetchArticlesIntentProcessor` to clear the `articles` list when fetching.

CLOSES #54