### PR TITLE
fix(article): Ensure initial loading state and prevent re-fetching on…

### DIFF
--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
@@ -120,7 +120,9 @@ fun ArticleScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.sendIntent(Intent.FetchArticle(articleId))
+        if (uiState.isLoading && uiState.content.isEmpty()) {
+            viewModel.sendIntent(Intent.FetchArticle(articleId))
+        }
     }
     ArticleScreen(
         uiState = uiState,

--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/UiState.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/UiState.kt
@@ -7,7 +7,7 @@ import com.kesicollection.feature.article.uimodel.UiPodcast
 val initialState = UiArticleState()
 
 data class UiArticleState(
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val title: String = "",
     val imageUrl: String = "",
     val podcast: UiPodcast? = null,

--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/intent/FetchArticleIntentProcessor.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/intent/FetchArticleIntentProcessor.kt
@@ -43,7 +43,7 @@ class FetchArticleIntentProcessor(
     private val crashlyticsWrapper: CrashlyticsWrapper,
 ) : IntentProcessor<UiArticleState> {
     override suspend fun processIntent(reducer: (Reducer<UiArticleState>) -> Unit) {
-        reducer { copy(isLoading = true, error = null) }
+        reducer { copy(isLoading = true, error = null, content = emptyList()) }
         try {
             val result = getArticleByIdUseCase(articleId).getOrThrow()
             reducer {
@@ -69,11 +69,13 @@ class FetchArticleIntentProcessor(
                 )
             }
         } catch (e: Exception) {
-            crashlyticsWrapper.recordException(e, mapOf(
-                crashlyticsWrapper.params.screenName to "Article",
-                crashlyticsWrapper.params.className to "FetchArticleIntentProcessor",
-                crashlyticsWrapper.params.action to "fetch",
-            ))
+            crashlyticsWrapper.recordException(
+                e, mapOf(
+                    crashlyticsWrapper.params.screenName to "Article",
+                    crashlyticsWrapper.params.className to "FetchArticleIntentProcessor",
+                    crashlyticsWrapper.params.action to "fetch",
+                )
+            )
             reducer {
                 copy(
                     isLoading = false,


### PR DESCRIPTION
… config change

- Set `isLoading` to `true` by default in `UiArticleState`.
- Clear `content` in `FetchArticleIntentProcessor` when starting to fetch.
- Only fetch article in `ArticleScreen` if `isLoading` is true and `content` is empty to prevent re-fetching on configuration changes.

CLOSES #61