### PR TITLE
feat(markdown): Add Markdown rendering with Kotlin syntax highlighting

### DIFF
--- a/core/uisystem/build.gradle.kts
+++ b/core/uisystem/build.gradle.kts
@@ -18,7 +18,10 @@ dependencies {
     api(libs.androidx.compose.ui.util)
     api(libs.play.services.ads)
     api(projects.core.app)
+
     implementation(libs.coil.core)
+    implementation(libs.markdown)
+    implementation(libs.syntax.highlight)
 
     debugImplementation(libs.bundles.androidx.compose.ui.test)
     androidTestImplementation(libs.androidx.test.rules)

--- a/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/KotlinGrammarLocator.kt
+++ b/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/KotlinGrammarLocator.kt
@@ -1,0 +1,218 @@
+package com.kesicollection.core.uisystem
+
+import io.noties.prism4j.GrammarLocator
+import io.noties.prism4j.GrammarUtils
+import io.noties.prism4j.Prism4j
+import io.noties.prism4j.Prism4j.grammar
+import io.noties.prism4j.Prism4j.pattern
+import io.noties.prism4j.Prism4j.token
+import java.util.regex.Pattern
+import java.util.regex.Pattern.compile
+
+/**
+ * [GrammarLocator] for the Kotlin language. This class provides the Prism4j grammar
+ * for Kotlin, enabling syntax highlighting of Kotlin code within the application.
+ * It utilizes a predefined grammar structure to identify various language elements
+ * like keywords, comments, strings, etc.
+ */
+class KotlinGrammarLocator : GrammarLocator {
+    /**
+     * Retrieves the Prism4j.Grammar for the specified language.
+     *
+     * @param prism4j The [Prism4j] instance.
+     * @param language The name of the language for which to get the grammar.
+     *                 This implementation specifically handles "kotlin".
+     * @return The [Prism4j.Grammar] for Kotlin if the language is "kotlin", otherwise null
+     *         (though in this specific implementation, it always returns the Kotlin grammar
+     *         if called, as it's tied to the `languages()` method).
+     */
+    override fun grammar(
+        prism4j: Prism4j,
+        language: String
+    ): Prism4j.Grammar? = PrismKotlin.create()
+
+    /**
+     * Returns a set of language names that this locator can provide grammars for.
+     *
+     * @return A set containing "kotlin".
+     */
+    override fun languages(): Set<String?> =
+        setOf("kotlin")
+}
+
+/**
+ * Object responsible for creating and configuring the Prism4j grammar for the Kotlin language.
+ * This object defines tokens and patterns that Prism4j uses to parse and highlight Kotlin code.
+ */
+object PrismKotlin {
+    /**
+     * Creates and returns a [Prism4j.Grammar] for the Kotlin language.
+     * This method defines the various tokens (like comments, strings, keywords, etc.) and their patterns.
+     * @return The fully configured [Prism4j.Grammar] for Kotlin.
+     */
+    fun create(): Prism4j.Grammar {
+        val kotlin = grammar(
+            "kotlin",
+            token(
+                "comment",
+                pattern(compile("(^|[^\\\\])\\/\\*[\\s\\S]*?(?:\\*\\/|$)"), true),
+                pattern(compile("(^|[^\\\\:])\\/\\/.*"), true, true)
+            ),
+            token(
+                "string",
+                pattern(
+                    compile("([\"'])(?:\\\\(?:\\r\\n|[\\s\\S])|(?!\\1)[^\\\\\\r\\n])*\\1"),
+                    false,
+                    true
+                )
+            ),
+            token(
+                "class-name",
+                pattern(
+                    compile("((?:\\b(?:class|interface|extends|implements|trait|instanceof|new)\\s+)|(?:catch\\s+\\())[\\w.\\\\]+"),
+                    true,
+                    false,
+                    null,
+                    grammar("inside", token("punctuation", pattern(compile("[.\\\\]"))))
+                )
+            ),
+            token(
+                "keyword",
+                pattern(compile("\\b(?:if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\\b"))
+            ),
+            token("boolean", pattern(compile("\\b(?:true|false)\\b"))),
+            token("function", pattern(compile("[a-z0-9_]+(?=\\()", Pattern.CASE_INSENSITIVE))),
+            token(
+                "number",
+                pattern(
+                    compile(
+                        "\\b0x[\\da-f]+\\b|(?:\\b\\d+\\.?\\d*|\\B\\.\\d+)(?:e[+-]?\\d+)?",
+                        Pattern.CASE_INSENSITIVE
+                    )
+                )
+            ),
+            token(
+                "operator",
+                pattern(compile("--?|\\+\\+?|!=?=?|<=?|>=?|==?=?|&&?|\\|\\|?|\\?|\\*|\\/|~|\\^|%"))
+            ),
+            token("punctuation", pattern(compile("[{}\\[\\];(),.:]"))),
+            token(
+                "keyword",
+                pattern(
+                    compile("(^|[^.])\\b(?:abstract|actual|annotation|as|break|by|catch|class|companion|const|constructor|continue|crossinline|data|do|dynamic|else|enum|expect|external|final|finally|for|fun|get|if|import|in|infix|init|inline|inner|interface|internal|is|lateinit|noinline|null|object|open|operator|out|override|package|private|protected|public|reified|return|sealed|set|super|suspend|tailrec|this|throw|to|try|typealias|val|var|vararg|when|where|while)\\b"),
+                    true
+                )
+            ),
+            token(
+                "function",
+                pattern(compile("\\w+(?=\\s*\\()")),
+                pattern(compile("(\\.)\\w+(?=\\s*\\{)"), true)
+            ),
+            token(
+                "number",
+                pattern(compile("\\b(?:0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*|0[bB][01]+(?:_[01]+)*|\\d+(?:_\\d+)*(?:\\.\\d+(?:_\\d+)*)?(?:[eE][+-]?\\d+(?:_\\d+)*)?[fFL]?)\\b"))
+            ),
+            token(
+                "operator",
+                pattern(compile("\\+[+=]?|-[-=>]?|==?=?|!(?:!|==?)?|[\\/*%<>]=?|[?:]:?|\\.\\.|&&|\\|\\||\\b(?:and|inv|or|shl|shr|ushr|xor)\\b"))
+            )
+        )
+        GrammarUtils.insertBeforeToken(
+            kotlin, "string",
+            token(
+                "raw-string",
+                pattern(compile("(\"\"\"|''')[\\s\\S]*?\\1"), false, false, "string")
+            )
+        );
+
+        GrammarUtils.insertBeforeToken(
+            kotlin, "keyword",
+            token(
+                "annotation",
+                pattern(
+                    compile("\\B@(?:\\w+:)?(?:[A-Z]\\w*|\\[[^\\]]+\\])"),
+                    false,
+                    false,
+                    "builtin"
+                )
+            )
+        );
+
+        GrammarUtils.insertBeforeToken(
+            kotlin, "function",
+            token("label", pattern(compile("\\w+@|@\\w+"), false, false, "symbol"))
+        );
+
+        // this grammar has 1 token: interpolation, which has 2 patterns
+        val interpolationInside: Prism4j.Grammar
+        run { // Scope function to mimic the Java block
+            val tokens = mutableListOf<Prism4j.Token>() // Use mutableListOf for Kotlin
+            tokens.add(
+                token(
+                    "delimiter",
+                    pattern(compile("^\\$\\{|\\}$"), false, false, "variable")
+                )
+            )
+            tokens.addAll(kotlin.tokens())
+
+            interpolationInside = grammar(
+                "inside",
+                token(
+                    "interpolation",
+                    pattern(
+                        compile("\\$\\{[^}]+\\}"),
+                        false,
+                        false,
+                        null,
+                        grammar("inside", tokens)
+                    ),
+                    pattern(compile("\\$\\w+"), false, false, "variable")
+                )
+            )
+        }
+
+        val stringToken = GrammarUtils.findToken(kotlin, "string")
+        val rawStringToken = GrammarUtils.findToken(kotlin, "raw-string")
+
+        if (stringToken != null && rawStringToken != null) {
+            val stringPattern = stringToken.patterns().get(0)
+            val rawStringPattern = rawStringToken.patterns().get(0)
+
+            // It's generally safer to add the new pattern first and then remove the old one,
+            // or ensure the list supports modification during iteration if removing first.
+            // Kotlin's List from Java interop should behave similarly here.
+
+            stringToken.patterns().add(
+                pattern(
+                    stringPattern.regex(),
+                    stringPattern.lookbehind(),
+                    stringPattern.greedy(),
+                    stringPattern.alias(),
+                    interpolationInside
+                )
+            )
+            stringToken.patterns().removeAt(0) // Use removeAt for indexed removal
+
+            rawStringToken.patterns().add(
+                pattern(
+                    rawStringPattern.regex(),
+                    rawStringPattern.lookbehind(),
+                    rawStringPattern.greedy(),
+                    rawStringPattern.alias(),
+                    interpolationInside
+                )
+            )
+            rawStringToken.patterns().removeAt(0)
+
+        } else {
+            // Consider using Kotlin's require or check functions for preconditions
+            // For example: require(stringToken != null && rawStringToken != null) { "message" }
+            throw RuntimeException(
+                "Unexpected state, cannot find `string` and/or `raw-string` tokens " +
+                        "inside kotlin grammar"
+            )
+        }
+
+        return kotlin
+    }
+}

--- a/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/component/KMarkdown.kt
+++ b/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/component/KMarkdown.kt
@@ -1,0 +1,136 @@
+package com.kesicollection.core.uisystem.component
+
+import android.graphics.Typeface
+import android.widget.TextView
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.res.ResourcesCompat
+import com.kesicollection.core.uisystem.KotlinGrammarLocator
+import com.kesicollection.core.uisystem.R
+import com.kesicollection.core.uisystem.theme.KesiTheme
+import io.noties.markwon.Markwon
+import io.noties.markwon.syntax.Prism4jThemeDarkula
+import io.noties.markwon.syntax.SyntaxHighlightPlugin
+import io.noties.prism4j.Prism4j
+
+/**
+ * Composable function to display Markdown text.
+ *
+ * This function uses the Markwon library to render Markdown content within an AndroidView.
+ * It supports syntax highlighting for Kotlin code blocks using Prism4j.
+ * The text color, size, and font are styled based on the MaterialTheme.
+ *
+ * @param text The Markdown string to display.
+ * @param modifier Optional [Modifier] to be applied to the composable.
+ */
+@Composable
+fun KMarkdown(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    // Get the current context.
+    val context = LocalContext.current
+
+    // Initialize Markwon with syntax highlighting for Kotlin.
+    val markwon = Markwon.builder(context)
+        // Use the SyntaxHighlightPlugin with Prism4j for Kotlin.
+        // KotlinGrammarLocator provides the grammar for Kotlin.
+        .usePlugin(
+            SyntaxHighlightPlugin.create(
+                Prism4j(KotlinGrammarLocator()), Prism4jThemeDarkula.create()
+            )
+        )
+        .build()
+
+    // Get the primary text color from the MaterialTheme.
+    val m3PrimaryColor = MaterialTheme.colorScheme.onBackground
+    // Get the body large text style from the MaterialTheme.
+    val m3BodyLargeTextStyle = MaterialTheme.typography.bodyLarge
+
+    // Use AndroidView to embed the TextView that will display the Markdown.
+    AndroidView(
+        modifier = modifier,
+        // Factory function to create the TextView.
+        factory = { ctx ->
+            TextView(ctx).apply {
+                // Set the text color from the MaterialTheme.
+                setTextColor(m3PrimaryColor.toArgb())
+                // Set the text size from the MaterialTheme.
+                textSize = m3BodyLargeTextStyle.fontSize.value
+                // Set the typeface. Attempt to load a custom font, fallback to default.
+                typeface = m3BodyLargeTextStyle.fontFamily?.let {
+                    try {
+                        // Attempt to load the custom font 'lexend_regular'.
+                        ResourcesCompat.getFont(context, R.font.lexend_regular)
+                    } catch (e: Exception) {
+                        Typeface.DEFAULT // Fallback to the default typeface if the custom font fails to load.
+                    }
+                } ?: Typeface.DEFAULT // Fallback to default if fontFamily is null.
+            }
+        },
+        // Update function to apply changes to the TextView when the input 'text' or theme changes.
+        update = { textView ->
+            // Re-apply text color in case of theme changes.
+            textView.setTextColor(m3PrimaryColor.toArgb())
+            // Re-apply text size in case of theme changes.
+            textView.textSize = m3BodyLargeTextStyle.fontSize.value
+            // Set the Markdown content to the TextView using Markwon.
+            markwon.setMarkdown(textView, text)
+        }
+    )
+}
+
+
+@Composable
+/**
+ * Private composable function to demonstrate the usage of [KMarkdown].
+ * This is typically used for previews or internal examples.
+ *
+ * @param modifier Optional [Modifier] to be applied to the [KMarkdown] composable.
+ * @param text The Markdown string to display. Defaults to [codeExample].
+ */
+private fun ExampleKMarkdown(
+    modifier: Modifier = Modifier,
+    text: String = codeExample,
+) {
+    KMarkdown(
+        text = text,
+        modifier = modifier
+    )
+}
+
+@PreviewLightDark
+/**
+ * Private composable function for previewing [ExampleKMarkdown] in both light and dark themes.
+ */
+@Composable
+private fun PreviewKMarkdown() {
+    KesiTheme {
+        ExampleKMarkdown()
+    }
+}
+
+/**
+ * A constant string containing an example Markdown content with a Kotlin code block.
+ */
+const val codeExample = """
+## Code
+
+```kotlin
+class KotlinGrammarLocator : GrammarLocator {
+    override fun grammar(
+        prism4j: Prism4j,
+        language: String
+    ): Prism4j.Grammar? = PrismKotlin.create()
+
+    override fun languages(): Set<String?> =
+        setOf("kotlin")
+}
+```
+---
+"""

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ material = "1.12.0"
 markdown = "4.6.2"
 okhttp = "4.12.0"
 playServicesAds = "24.2.0"
+syntaxHighlight = "4.6.2"
 retrofit = "2.11.0"
 robolectric = "4.14.1"
 room = "2.6.1"
@@ -100,6 +101,7 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+syntax-highlight = { group = "io.noties.markwon", name = "syntax-highlight", version.ref = "syntaxHighlight" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }


### PR DESCRIPTION
This commit introduces Markdown rendering capabilities to the `core/uisystem` module. It includes a new composable `KMarkdown` that utilizes the Markwon library to display Markdown text.

Key changes:
- Added `KMarkdown` composable function to render Markdown content.
- Integrated Markwon library for Markdown parsing and rendering.
- Implemented Kotlin syntax highlighting using Prism4j via a custom `KotlinGrammarLocator`.
- The `KMarkdown` composable styles text color, size, and font based on the MaterialTheme.
- Added new dependencies: `io.noties.markwon:markwon-markdown` and `io.noties.markwon:syntax-highlight`.
- Included preview examples for `KMarkdown`.

CLOSES #70 