### PR TITLE
fix(article): Resolve KMarkdown scrolling and content display issues

### DIFF
--- a/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/component/KMarkdown.kt
+++ b/core/uisystem/src/main/kotlin/com/kesicollection/core/uisystem/component/KMarkdown.kt
@@ -1,6 +1,7 @@
 package com.kesicollection.core.uisystem.component
 
 import android.graphics.Typeface
+import android.view.ViewGroup
 import android.widget.TextView
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -58,6 +59,10 @@ fun KMarkdown(
         // Factory function to create the TextView.
         factory = { ctx ->
             TextView(ctx).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
                 // Set the text color from the MaterialTheme.
                 setTextColor(m3PrimaryColor.toArgb())
                 // Set the text size from the MaterialTheme.

--- a/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
+++ b/feature/article/src/main/kotlin/com/kesicollection/feature/article/ArticleScreen.kt
@@ -244,7 +244,9 @@ internal fun ArticleScreen(
                 Column(
                     modifier = Modifier
                         .verticalScroll(contentScrollState)
-                        .padding(horizontal = 16.dp),
+                        .weight(1f)
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     AsyncImage(
@@ -272,8 +274,6 @@ internal fun ArticleScreen(
                     }
                     KMarkdown(
                         text = uiState.content,
-                        Modifier
-                            .padding()
                     )
                 }
                 KAdView(
@@ -281,7 +281,6 @@ internal fun ArticleScreen(
                     screenName = "Article",
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = safeContent.calculateBottomPadding())
                 )
             }
         }


### PR DESCRIPTION
This commit addresses two issues related to the `KMarkdown` component within the `ArticleScreen`:

- **Scrolling Issue:** The `KMarkdown` component was not scrolling correctly, preventing users from viewing the entire content. This has been fixed by adjusting the layout weights and padding in `ArticleScreen.kt`. The content column now properly utilizes available space and scrolls as expected.
- **Content Truncation:** The `KMarkdown` component was truncating content due to its default `WRAP_CONTENT` behavior. This has been resolved by setting `layoutParams` to `MATCH_PARENT` for width and `WRAP_CONTENT` for height within `KMarkdown.kt`, ensuring the component expands to display all content.

Specific changes:

- **`ArticleScreen.kt`**:
    - Modified the `Column` modifier to use `weight(1f)` for proper space allocation.
    - Added `padding(bottom = 16.dp)` to the content `Column` for better visual spacing.
    - Removed redundant padding from the `KMarkdown` component.
    - Removed bottom padding from the `KAdView` as it's now handled by the parent `Column`.
- **`KMarkdown.kt`**:
    - Set `layoutParams` for the underlying `TextView` to `ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)`.

CLOSES #76 