### PR TITLE
feat(discover): Add FakeDiscover and test DiscoverRepositoryImpl

### DIFF
--- a/data/repository/src/test/kotlin/com/kesicollection/data/repository/DiscoverRepositoryImplTest.kt
+++ b/data/repository/src/test/kotlin/com/kesicollection/data/repository/DiscoverRepositoryImplTest.kt
@@ -1,0 +1,71 @@
+package com.kesicollection.data.repository
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.api.DiscoverApi
+import com.kesicollection.test.core.fake.FakeDiscover
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Test class for [DiscoverRepositoryImpl].
+ */
+class DiscoverRepositoryImplTest {
+
+    private val discoverApi: DiscoverApi = mockk()
+    private lateinit var discoverRepository: DiscoverRepositoryImpl
+
+    /**
+     * Sets up the test environment before each test.
+     * Initializes [discoverRepository] with a mocked [DiscoverApi].
+     */
+    @Before
+    fun setUp() {
+        discoverRepository = DiscoverRepositoryImpl(
+            remoteDiscoverApi = discoverApi
+        )
+    }
+
+    /**
+     * Tests that [DiscoverRepositoryImpl.getDiscoverContent] returns a successful result
+     * when the API call is successful.
+     */
+    @Test
+    fun `getDiscoverContent returns success when api call is successful`() = runTest {
+        // Given
+        val mockDiscoverData = FakeDiscover.items.first()
+        coEvery { discoverApi.getDiscoverContent() } returns Result.success(mockDiscoverData)
+
+        // When
+        val result = discoverRepository.getDiscoverContent()
+
+        // Then
+        coVerify(exactly = 1) { discoverApi.getDiscoverContent() }
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(mockDiscoverData)
+    }
+
+    /**
+     * Tests that [DiscoverRepositoryImpl.getDiscoverContent] returns a failure result
+     * when the API call fails.
+     */
+    @Test
+    fun `getDiscoverContent returns failure when api call fails`() = runTest {
+        // Given
+        val expectedException = IOException("Network error")
+        coEvery { discoverApi.getDiscoverContent() } returns Result.failure(expectedException)
+
+        // When
+        val result = discoverRepository.getDiscoverContent()
+
+        // Then
+        coVerify(exactly = 1) { discoverApi.getDiscoverContent() }
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(expectedException)
+    }
+
+}

--- a/test/core/src/main/kotlin/com/kesicollection/test/core/fake/FakeDiscover.kt
+++ b/test/core/src/main/kotlin/com/kesicollection/test/core/fake/FakeDiscover.kt
@@ -1,0 +1,70 @@
+package com.kesicollection.test.core.fake
+
+import com.kesicollection.core.model.Category
+import com.kesicollection.core.model.Content
+import com.kesicollection.core.model.ContentType
+import com.kesicollection.core.model.Discover
+import com.kesicollection.core.model.PromotedContent
+
+/**
+ * Object providing fake data for Discover items.
+ * This is used for testing and development purposes to simulate the data
+ * that would typically be fetched from a backend or database.
+ */
+object FakeDiscover {
+    /**
+     * A list of Discover items, each populated with fake data.
+     * The list contains 10 Discover items by default.
+     */
+    val items: List<Discover> = List(10) { index ->
+        // Base identifiers for content and category to ensure uniqueness.
+        val contentIdBase = "content_${index}_"
+        val categoryIdBase = "category_${index}_"
+
+        // Create a Discover item.
+        Discover(
+            /**
+             * A list of featured content items.
+             * Each Discover item has 3 featured content items.
+             */
+            featured = List(3) { featIndex ->
+                Content(
+                    id = "${contentIdBase}featured_$featIndex",
+                    img = "${contentIdBase}featured_$featIndex.jpg",
+                    // Assign a random content type from the available ContentType enum entries.
+                    type = ContentType.entries.toTypedArray().random(),
+                    title = "Featured Title ${index}_$featIndex",
+                    description = "This is a detailed description for featured content ${index}_$featIndex."
+                )
+            },
+            /**
+             * A list of promoted content sections.
+             * Each Discover item has 2 promoted content sections.
+             */
+            promotedContent = List(2) { promoIndex ->
+                // Create a Category for the promoted content section.
+                val category = Category(
+                    id = "${categoryIdBase}promo_$promoIndex",
+                    name = "Category ${index}_$promoIndex"
+                )
+                // Create a PromotedContent item.
+                PromotedContent(
+                    category = category,
+                    /**
+                     * A list of content items within this promoted section.
+                     * Each promoted section has 2 content items.
+                     */
+                    content = List(2) { contentPromoIndex ->
+                        Content(
+                            id = "${contentIdBase}promoted_${promoIndex}_$contentPromoIndex",
+                            img = "${contentIdBase}promoted_${promoIndex}_$contentPromoIndex.jpg",
+                            type = ContentType.entries.toTypedArray().random(),
+                            title = "Promoted Content ${index}_${promoIndex}_$contentPromoIndex for ${category.name}",
+                            description = "Description for promoted item ${index}_${promoIndex}_$contentPromoIndex under ${category.name}."
+                        )
+                    }
+                )
+            }
+        )
+    }
+}


### PR DESCRIPTION
This commit introduces fake data generation for `Discover` items and unit tests for `DiscoverRepositoryImpl`.

- Created `FakeDiscover.kt` in `test/core` to provide mock `Discover` data for testing purposes. It generates a list of `Discover` items with populated `featured` and `promotedContent` sections.
- Implemented `DiscoverRepositoryImplTest.kt` in `data/repository` to unit test the `DiscoverRepositoryImpl`.
  - Added tests to verify successful and failure scenarios for the `getDiscoverContent` method, ensuring it correctly handles responses from the `DiscoverApi`.

CLOSES #93 