### PR TITLE
test(retrofit): Add unit tests for RetrofitArticleApi

### DIFF
--- a/data/retrofit/build.gradle.kts
+++ b/data/retrofit/build.gradle.kts
@@ -5,8 +5,11 @@ plugins {
 
 dependencies {
     api(projects.data.api)
+    
     implementation(projects.core.app)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)
     implementation(libs.okhttp.logging)
+
+    testImplementation(projects.test.core)
 }

--- a/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/RetrofitArticleApiTest.kt
+++ b/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/RetrofitArticleApiTest.kt
@@ -1,0 +1,102 @@
+package com.kesicollection.data.retrofit
+
+import com.kesicollection.data.retrofit.fake.FakeNetworkArticle
+import com.kesicollection.data.retrofit.fake.FakeNetworkIndexArticle
+import com.kesicollection.data.retrofit.model.kesiandroid.asArticle
+import com.kesicollection.data.retrofit.service.KesiAndroidService
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest // or runBlockingTest for older versions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class RetrofitArticleApiTest {
+
+    private lateinit var mockKesiAndroidService: KesiAndroidService
+    private lateinit var retrofitArticleApi: RetrofitArticleApi
+
+    @Before
+    fun setUp() {
+        mockKesiAndroidService = mockk()
+        retrofitArticleApi = RetrofitArticleApi(mockKesiAndroidService)
+    }
+
+    // --- Tests for getAll() ---
+
+    @Test
+    fun `getAll returns success with mapped articles when service succeeds`() = runTest {
+        coEvery { mockKesiAndroidService.fetchAllArticles() } returns FakeNetworkIndexArticle.items
+
+        // When
+        val result = retrofitArticleApi.getAll()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(FakeNetworkIndexArticle.items.map { it.asArticle() }, result.getOrNull())
+    }
+
+    @Test
+    fun `getAll returns failure when service throws IOException`() = runTest {
+        // Given
+        val expectedException = IOException("Network error")
+        coEvery { mockKesiAndroidService.fetchAllArticles() } throws expectedException
+
+        // When
+        val result = retrofitArticleApi.getAll()
+
+        // Then
+        assertTrue(result.isFailure)
+        assertEquals(expectedException, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `getAll returns success with empty list when service returns empty list`() = runTest {
+        // Given
+        coEvery { mockKesiAndroidService.fetchAllArticles() } returns emptyList()
+
+        // When
+        val result = retrofitArticleApi.getAll()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    // --- Tests for getContentById() ---
+
+    @Test
+    fun `getContentById returns success with mapped article when service succeeds`() = runTest {
+        // Given
+        val articleId = FakeNetworkArticle.items.first().id
+        val networkArticle = FakeNetworkArticle.items.first()
+
+        val expectedArticle = FakeNetworkArticle.items.first().asArticle()
+
+        coEvery { mockKesiAndroidService.getArticleById(articleId) } returns networkArticle
+
+        // When
+        val result = retrofitArticleApi.getContentById(articleId)
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(expectedArticle, result.getOrNull())
+    }
+
+    @Test
+    fun `getContentById returns failure when service throws IOException`() = runTest {
+        // Given
+        val articleId = "article123"
+        val expectedException = IOException("Network error for specific ID")
+        coEvery { mockKesiAndroidService.getArticleById(articleId) } throws expectedException
+
+        // When
+        val result = retrofitArticleApi.getContentById(articleId)
+
+        // Then
+        assertTrue(result.isFailure)
+        assertEquals(expectedException, result.exceptionOrNull())
+    }
+}

--- a/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/fake/FakeNetworkArticle.kt
+++ b/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/fake/FakeNetworkArticle.kt
@@ -1,0 +1,115 @@
+package com.kesicollection.data.retrofit.fake
+
+import com.kesicollection.data.retrofit.model.kesiandroid.NetworkArticle
+import com.kesicollection.data.retrofit.model.kesiandroid.NetworkPodcast
+
+object FakeNetworkArticle {
+
+    val items = listOf(
+        NetworkArticle(
+            id = "1",
+            title = "Article 1 Title",
+            description = "Description for article 1.",
+            img = "https://example.com/1.jpg",
+            markdown = "## Article 1 Content\n\nThis is the markdown content for article 1.",
+            podcast = NetworkPodcast(
+                id = "podcast1",
+                title = "Podcast for Article 1",
+                audio = "https://example.com/1.mp3",
+                img = "https://example.com/podcast_image1.jpg"
+            )
+        ),
+        NetworkArticle(
+            id = "2",
+            title = "Article 2 Title",
+            description = "Description for article 2.",
+            img = "https://example.com/2.jpg",
+            markdown = "## Article 2 Content\n\nThis is the markdown content for article 2.",
+            podcast = null
+        ),
+        NetworkArticle(
+            id = "3",
+            title = "Article 3 Title",
+            description = "Description for article 3.",
+            img = "https://example.com/3.jpg",
+            markdown = "## Article 3 Content\n\nThis is the markdown content for article 3.",
+            podcast = NetworkPodcast(
+                id = "podcast3",
+                title = "Podcast for Article 3",
+                audio = "https://example.com/3.mp3",
+                img = "https://example.com/podcast_image3.jpg"
+            )
+        ),
+        NetworkArticle(
+            id = "4",
+            title = "Article 4 Title",
+            description = "Description for article 4.",
+            img = "https://example.com/4.jpg",
+            markdown = "## Article 4 Content\n\nThis is the markdown content for article 4.",
+            podcast = null
+        ),
+        NetworkArticle(
+            id = "5",
+            title = "Article 5 Title",
+            description = "Description for article 5.",
+            img = "https://example.com/5.jpg",
+            markdown = "## Article 5 Content\n\nThis is the markdown content for article 5.",
+            podcast = NetworkPodcast(
+                id = "podcast5",
+                title = "Podcast for Article 5",
+                audio = "https://example.com/5.mp3",
+                img = "https://example.com/podcast_image5.jpg"
+            )
+        ),
+        NetworkArticle(
+            id = "6",
+            title = "Article 6 Title",
+            description = "Description for article 6.",
+            img = "https://example.com/6.jpg",
+            markdown = "## Article 6 Content\n\nThis is the markdown content for article 6.",
+            podcast = null
+        ),
+        NetworkArticle(
+            id = "7",
+            title = "Article 7 Title",
+            description = "Description for article 7.",
+            img = "https://example.com/7.jpg",
+            markdown = "## Article 7 Content\n\nThis is the markdown content for article 7.",
+            podcast = NetworkPodcast(
+                id = "podcast7",
+                title = "Podcast for Article 7",
+                audio = "https://example.com/7.mp3",
+                img = "https://example.com/podcast_image7.jpg"
+            )
+        ),
+        NetworkArticle(
+            id = "8",
+            title = "Article 8 Title",
+            description = "Description for article 8.",
+            img = "https://example.com/8.jpg",
+            markdown = "## Article 8 Content\n\nThis is the markdown content for article 8.",
+            podcast = null
+        ),
+        NetworkArticle(
+            id = "9",
+            title = "Article 9 Title",
+            description = "Description for article 9.",
+            img = "https://example.com/9.jpg",
+            markdown = "## Article 9 Content\n\nThis is the markdown content for article 9.",
+            podcast = NetworkPodcast(
+                id = "podcast9",
+                title = "Podcast for Article 9",
+                audio = "https://example.com/9.mp3",
+                img = "https://example.com/podcast_image9.jpg"
+            )
+        ),
+        NetworkArticle(
+            id = "10",
+            title = "Article 10 Title",
+            description = "Description for article 10.",
+            img = "https://example.com/10.jpg",
+            markdown = "## Article 10 Content\n\nThis is the markdown content for article 10.",
+            podcast = null
+        )
+    )
+}

--- a/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/fake/FakeNetworkIndexArticle.kt
+++ b/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/fake/FakeNetworkIndexArticle.kt
@@ -1,0 +1,68 @@
+package com.kesicollection.data.retrofit.fake
+
+import com.kesicollection.data.retrofit.model.kesiandroid.NetworkIndexArticle
+
+object FakeNetworkIndexArticle {
+    val items = listOf(
+        NetworkIndexArticle(
+            id = "1",
+            title = "Article 1 Title",
+            description = "Description for article 1.",
+            img = "image1.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "2",
+            title = "Article 2 Title",
+            description = "Description for article 2.",
+            img = "image2.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "3",
+            title = "Article 3 Title",
+            description = "Description for article 3.",
+            img = "image3.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "4",
+            title = "Article 4 Title",
+            description = "Description for article 4.",
+            img = "image4.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "5",
+            title = "Article 5 Title",
+            description = "Description for article 5.",
+            img = "image5.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "6",
+            title = "Article 6 Title",
+            description = "Description for article 6.",
+            img = "image6.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "7",
+            title = "Article 7 Title",
+            description = "Description for article 7.",
+            img = "image7.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "8",
+            title = "Article 8 Title",
+            description = "Description for article 8.",
+            img = "image8.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "9",
+            title = "Article 9 Title",
+            description = "Description for article 9.",
+            img = "image9.jpg"
+        ),
+        NetworkIndexArticle(
+            id = "10",
+            title = "Article 10 Title",
+            description = "Description for article 10.",
+            img = "image10.jpg"
+        )
+    )
+}


### PR DESCRIPTION
This commit introduces unit tests for the `RetrofitArticleApi` class.

- Added `FakeNetworkArticle.kt` and `FakeNetworkIndexArticle.kt` to provide mock data for testing.
- Created `RetrofitArticleApiTest.kt` with tests covering:
    - Successful retrieval of all articles.
    - Handling of network errors (IOException) when fetching all articles.
    - Successful retrieval of an empty list of articles.
    - Successful retrieval of an article by its ID.
    - Handling of network errors (IOException) when fetching an article by ID.
- Added `test.core` project dependency to `data/retrofit/build.gradle.kts` for testing utilities.

CLOSES #99 