### PR TITLE
test(podcast-api): Add unit tests for RetrofitPodcastApi

### DIFF
--- a/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/RetrofitPodcastApiTest.kt
+++ b/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/RetrofitPodcastApiTest.kt
@@ -1,0 +1,108 @@
+package com.kesicollection.data.retrofit
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.retrofit.fake.FakeNetworkPodcast
+import com.kesicollection.data.retrofit.model.kesiandroid.NetworkPodcast
+import com.kesicollection.data.retrofit.model.kesiandroid.asPodcast
+import com.kesicollection.data.retrofit.service.KesiAndroidService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class RetrofitPodcastApiTest {
+    private val mockKesiAndroidService: KesiAndroidService = mockk()
+    private lateinit var retrofitPodcastApi: RetrofitPodcastApi
+
+    @Before
+    fun setUp() {
+        retrofitPodcastApi = RetrofitPodcastApi(
+            kesiAndroidService = mockKesiAndroidService
+        )
+    }
+
+    @Test
+    fun `getPodcastById success - returns correct podcast`() = runTest {
+        // Arrange
+        val podcastId = FakeNetworkPodcast.items.first().id
+        val fakeNetworkPodcast = FakeNetworkPodcast.items.first()
+        val expectedPodcast = fakeNetworkPodcast.asPodcast()
+
+        coEvery { mockKesiAndroidService.getPodcastById(podcastId) } returns fakeNetworkPodcast
+
+        // Act
+        val result = retrofitPodcastApi.getPodcastById(podcastId)
+
+        // Assert
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(expectedPodcast)
+        coVerify(exactly = 1) { mockKesiAndroidService.getPodcastById(podcastId) }
+    }
+
+    @Test
+    fun `getPodcastById failure - returns error result`() = runTest {
+        // Arrange
+        val podcastId = "nonExistentId"
+        val exception = IOException("Network error")
+        coEvery { mockKesiAndroidService.getPodcastById(podcastId) } throws exception
+
+        // Act
+        val result = retrofitPodcastApi.getPodcastById(podcastId)
+
+        // Assert
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(exception)
+        coVerify(exactly = 1) { mockKesiAndroidService.getPodcastById(podcastId) }
+    }
+
+    @Test
+    fun `getAllPodcasts success - returns list of podcasts`() = runTest {
+        // Arrange
+        val fakeNetworkPodcasts = FakeNetworkPodcast.items
+        val expectedPodcasts = fakeNetworkPodcasts.map { it.asPodcast() }
+
+        coEvery { mockKesiAndroidService.getAllPodcasts() } returns fakeNetworkPodcasts
+
+        // Act
+        val result = retrofitPodcastApi.getAllPodcasts()
+
+        // Assert
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(expectedPodcasts)
+        coVerify(exactly = 1) { mockKesiAndroidService.getAllPodcasts() }
+    }
+
+    @Test
+    fun `getAllPodcasts success - returns empty list when service returns empty`() = runTest {
+        // Arrange
+        val emptyNetworkPodcasts = emptyList<NetworkPodcast>()
+        coEvery { mockKesiAndroidService.getAllPodcasts() } returns emptyNetworkPodcasts
+
+        // Act
+        val result = retrofitPodcastApi.getAllPodcasts()
+
+        // Assert
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEmpty()
+        coVerify(exactly = 1) { mockKesiAndroidService.getAllPodcasts() }
+    }
+
+    @Test
+    fun `getAllPodcasts failure - returns error result`() = runTest {
+        // Arrange
+        val exception = IOException("Network error")
+        coEvery { mockKesiAndroidService.getAllPodcasts() } throws exception
+
+        // Act
+        val result = retrofitPodcastApi.getAllPodcasts()
+
+        // Assert
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(exception)
+        coVerify(exactly = 1) { mockKesiAndroidService.getAllPodcasts() }
+    }
+
+}

--- a/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/fake/FakeNetworkPodcast.kt
+++ b/data/retrofit/src/test/kotlin/com/kesicollection/data/retrofit/fake/FakeNetworkPodcast.kt
@@ -1,0 +1,68 @@
+package com.kesicollection.data.retrofit.fake
+
+import com.kesicollection.data.retrofit.model.kesiandroid.NetworkPodcast
+
+object FakeNetworkPodcast {
+    val items = listOf(
+        NetworkPodcast(
+            id = "1",
+            title = "Tech Talks Weekly",
+            audio = "https://example.com/podcast1.mp3",
+            img = "https://example.com/image1.jpg"
+        ),
+        NetworkPodcast(
+            id = "2",
+            title = "Mystery Solved",
+            audio = "https://example.com/podcast2.mp3",
+            img = "https://example.com/image2.jpg"
+        ),
+        NetworkPodcast(
+            id = "3",
+            title = "The Culinary Corner",
+            audio = "https://example.com/podcast3.mp3",
+            img = "https://example.com/image3.jpg"
+        ),
+        NetworkPodcast(
+            id = "4",
+            title = "History Uncovered",
+            audio = "https://example.com/podcast4.mp3",
+            img = "https://example.com/image4.jpg"
+        ),
+        NetworkPodcast(
+            id = "5",
+            title = "Future of AI",
+            audio = "https://example.com/podcast5.mp3",
+            img = "https://example.com/image5.jpg"
+        ),
+        NetworkPodcast(
+            id = "6",
+            title = "Indie Music Hour",
+            audio = "https://example.com/podcast6.mp3",
+            img = "https://example.com/image6.jpg"
+        ),
+        NetworkPodcast(
+            id = "7",
+            title = "Global Finance Today",
+            audio = "https://example.com/podcast7.mp3",
+            img = "https://example.com/image7.jpg"
+        ),
+        NetworkPodcast(
+            id = "8",
+            title = "Space Adventures",
+            audio = "https://example.com/podcast8.mp3",
+            img = "https://example.com/image8.jpg"
+        ),
+        NetworkPodcast(
+            id = "9",
+            title = "Mindful Living",
+            audio = "https://example.com/podcast9.mp3",
+            img = "https://example.com/image9.jpg"
+        ),
+        NetworkPodcast(
+            id = "10",
+            title = "The Comedy Club",
+            audio = "https://example.com/podcast10.mp3",
+            img = "https://example.com/image10.jpg"
+        )
+    )
+}


### PR DESCRIPTION
This commit introduces unit tests for the `RetrofitPodcastApi` class. The tests cover the following scenarios for both `getPodcastById` and `getAllPodcasts` methods:
- Successful retrieval of data.
- Handling of network errors or exceptions.
- Correct handling of empty responses from the service.

A `FakeNetworkPodcast` object was created to provide mock data for these tests.

CLOSES #103