### PR TITLE
test(domain): Add unit tests for UseCase classes

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -6,4 +6,6 @@ plugins {
 dependencies {
     api(projects.core.model)
     implementation(projects.data.repository)
+
+    testImplementation(projects.test.core)
 }

--- a/domain/src/test/kotlin/com/kesicollection/domain/BookmarkArticleByIdUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/BookmarkArticleByIdUseCaseTest.kt
@@ -1,0 +1,201 @@
+package com.kesicollection.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.repository.BookmarkRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Test class for [BookmarkArticleByIdUseCase].
+ * This class contains unit tests to verify the behavior of the `BookmarkArticleByIdUseCase` class,
+ * ensuring it correctly interacts with the [BookmarkRepository] and handles various scenarios.
+ */
+class BookmarkArticleByIdUseCaseTest {
+
+    private lateinit var mockBookmarkRepository: BookmarkRepository
+    private lateinit var useCase: BookmarkArticleByIdUseCase // This is the class under test
+
+    /**
+     * Sets up the test environment before each test.
+     * Initializes the mock [BookmarkRepository] and the [BookmarkArticleByIdUseCase] instance.
+     */
+    @Before
+    fun setUp() {
+        mockBookmarkRepository = mockk<BookmarkRepository>()
+        // Instantiating the actual UseCase with the mock repository
+        useCase = BookmarkArticleByIdUseCase(mockBookmarkRepository)
+    }
+
+    /**
+     * Tests bookmarking an article with a valid ID.
+     * Verifies that the `bookmarkArticleById` method of the repository is called exactly once
+     * with the correct ID.
+     */
+    @Test
+    fun `Test bookmarking with a valid ID`() = runTest {
+        val testId = "validId123"
+        // Stub the repository method to do nothing when called with testId
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } just runs
+
+        // Invoke the use case with the test ID
+        // This internally calls the suspend operator fun invoke(id: String) of the use case.
+        useCase.invoke(testId) // Calling the suspend operator fun invoke(id: String)
+
+        // Verifying the interaction with the repository, as per the UseCase's implementation
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+    /**
+     * Tests bookmarking an article with an empty ID.
+     * Verifies that the repository's `bookmarkArticleById` method is called with the empty ID.
+     * This tests how the use case handles potentially invalid but technically acceptable input.
+     */
+    @Test
+    fun `Test bookmarking with an empty ID`() = runTest {
+        val testId = ""
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } just runs
+
+        useCase.invoke(testId)
+
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+    /**
+     * Tests bookmarking an article with an ID containing special characters.
+     * Verifies that the repository's `bookmarkArticleById` method is called with the ID
+     * containing special characters, ensuring these are handled correctly.
+     */
+    @Test
+    fun `Test bookmarking with an ID containing special characters`() = runTest {
+        val testId = "id-with-@#\$%-special*chars"
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } just runs
+
+        useCase.invoke(testId)
+
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+    /**
+     * Tests bookmarking an article with an extremely long ID.
+     * Verifies that the repository's `bookmarkArticleById` method is called with the long ID,
+     * testing the system's ability to handle large inputs.
+     */
+    @Test
+    fun `Test bookmarking with an extremely long ID`() = runTest {
+        val testId = "a".repeat(10000)
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } just runs
+
+        useCase.invoke(testId)
+
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+    /**
+     * Tests the scenario of a successful bookmarking operation.
+     * Ensures that the use case completes without throwing an exception and that the repository
+     * method is called as expected.
+     */
+    @Test
+    fun `Test successful bookmarking operation`() = runTest {
+        val testId = "successfulId"
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } just runs
+
+        useCase.invoke(testId) // Should complete without throwing
+
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+    /**
+     * Tests the use case's behavior when the `BookmarkRepository` throws an exception.
+     * Verifies that the exception is propagated correctly by the use case and that the
+     * exception details (type and message) are as expected.
+     */
+    @Test
+    fun `Test when bookmarkRepository throws an exception`() = runTest {
+        val testId = "exceptionId"
+        val expectedException = IOException("Database error")
+        // Simulate the repository method (which the use case calls) throwing an exception
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } throws expectedException
+
+        var caughtException: Throwable? = null
+        try {
+            // Invoke the use case, which should trigger the mocked exception from the repository
+            useCase.invoke(testId) // This will internally call the throwing mock
+        } catch (e: Throwable) {
+            caughtException = e
+        }
+
+        assertThat(caughtException).isNotNull()
+        assertThat(caughtException).isInstanceOf(IOException::class.java)
+        assertThat(caughtException).hasMessageThat().isEqualTo("Database error")
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+    /**
+     * Tests multiple concurrent calls to the use case with the same ID.
+     * Verifies that the repository's `bookmarkArticleById` method is called for each concurrent
+     * invocation, ensuring that concurrent requests are handled independently.
+     * This is important for understanding potential race conditions or resource contention.
+     */
+    @Test
+    fun `Test multiple concurrent calls with the same ID`() = runTest {
+        val testId = "concurrentSameId"
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } just runs
+
+        val job1 = launch { useCase.invoke(testId) }
+        val job2 = launch { useCase.invoke(testId) }
+
+        job1.join()
+        job2.join()
+
+        // Since the use case simply passes the call through, the repository method
+        // will be called for each invocation.
+        coVerify(exactly = 2) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+    /**
+     * Tests multiple concurrent calls to the use case with different IDs.
+     * Verifies that the repository's `bookmarkArticleById` method is called once for each
+     * unique ID, ensuring correct handling of concurrent requests with different parameters.
+     */
+    @Test
+    fun `Test multiple concurrent calls with different IDs`() = runTest {
+        val testId1 = "concurrentId1"
+        val testId2 = "concurrentId2"
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId1) } just runs
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId2) } just runs
+
+        val job1 = launch { useCase.invoke(testId1) }
+        val job2 = launch { useCase.invoke(testId2) }
+
+        job1.join()
+        job2.join()
+
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId1) }
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId2) }
+    }
+
+    /**
+     * Tests the direct interaction with the mocked `BookmarkRepository`.
+     * This is a basic test to ensure that the use case correctly delegates the call to
+     * the repository's `bookmarkArticleById` method.
+     */
+    @Test
+    fun `Test interaction with mocked BookmarkRepository`() = runTest {
+        val testId = "interactionTestId"
+        coEvery { mockBookmarkRepository.bookmarkArticleById(testId) } just runs
+
+        useCase.invoke(testId)
+
+        coVerify(exactly = 1) { mockBookmarkRepository.bookmarkArticleById(testId) }
+    }
+
+}

--- a/domain/src/test/kotlin/com/kesicollection/domain/GetArticleByIdUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/GetArticleByIdUseCaseTest.kt
@@ -1,0 +1,120 @@
+package com.kesicollection.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.repository.ArticleRepository
+import com.kesicollection.test.core.fake.FakeArticles
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import kotlin.test.Test
+
+/**
+ * Unit tests for the [GetArticleByIdUseCase].
+ * This class tests the behavior of the use case when retrieving an article by its ID.
+ */
+class GetArticleByIdUseCaseTest {
+
+    private lateinit var mockArticleRepository: ArticleRepository
+    private lateinit var getArticleByIdUseCase: GetArticleByIdUseCase
+
+    /**
+     * Sets up the test environment before each test.
+     * Initializes the mock [ArticleRepository] and the [GetArticleByIdUseCase] with the mock repository.
+     */
+    @Before
+    fun setUp() {
+        mockArticleRepository = mockk()
+        getArticleByIdUseCase = GetArticleByIdUseCase(mockArticleRepository)
+    }
+
+    /**
+     * Tests that invoking the use case with an existing article ID returns a successful result
+     * containing the expected article.
+     *
+     * Steps:
+     * 1. **Given**: An existing article ID and the corresponding expected article.
+     *    The mock repository is configured to return a successful result with the article when
+     *    `getArticleById` is called with this ID.
+     * 2. **When**: The [GetArticleByIdUseCase] is invoked with the article ID.
+     * 3. **Then**: The result should be successful, and the article within the result should
+     *    match the expected article.
+     */
+    @Test
+    fun `invoke with existing article ID returns success with article`() = runTest {
+        // Given
+        val articleId = FakeArticles.items.first().id
+        val expectedArticle = FakeArticles.items.first()
+        // Mock the repository to return the expected article for the given ID
+        coEvery { mockArticleRepository.getArticleById(articleId) } returns Result.success(expectedArticle)
+
+        // When
+        val result = getArticleByIdUseCase(articleId)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(expectedArticle)
+    }
+
+    /**
+     * Tests that invoking the use case with a non-existent article ID returns a failure result.
+     *
+     * Steps:
+     * 1. **Given**: A non-existent article ID and an expected exception (e.g., [NoSuchElementException]).
+     *    The mock repository is configured to return a failure result with this exception when
+     *    `getArticleById` is called with this ID.
+     * 2. **When**: The [GetArticleByIdUseCase] is invoked with the non-existent article ID.
+     * 3. **Then**: The result should be a failure.
+     *    The exception within the result should match the expected exception, be an instance of
+     *    [NoSuchElementException], and have the expected message.
+     */
+    @Test
+    fun `invoke with non-existent article ID returns failure`() = runTest {
+        // Given
+        val articleId = "unknown"
+        val expectedException = NoSuchElementException("Article not found")
+        // Mock the repository to return a failure for the non-existent ID
+        coEvery { mockArticleRepository.getArticleById(articleId) } returns Result.failure(expectedException)
+
+
+        // When
+        val result = getArticleByIdUseCase(articleId)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(expectedException)
+        assertThat(result.exceptionOrNull()).isInstanceOf(NoSuchElementException::class.java)
+        assertThat(result.exceptionOrNull()?.message).isEqualTo("Article not found")
+    }
+
+    /**
+     * Tests that invoking the use case with an empty article ID returns a failure result
+     * if the underlying repository is configured to handle it that way.
+     *
+     * Steps:
+     * 1. **Given**: An empty article ID and an expected exception (e.g., [IllegalArgumentException]).
+     *    The mock repository is configured to return a failure result with this exception when
+     *    `getArticleById` is called with an empty ID.
+     * 2. **When**: The [GetArticleByIdUseCase] is invoked with the empty article ID.
+     * 3. **Then**: The result should be a failure.
+     *    The exception within the result should match the expected exception and be an instance of
+     *    [IllegalArgumentException].
+     */
+    @Test
+    fun `invoke with empty article ID returns failure if repository dictates`() = runTest {
+        // Given
+        val articleId = ""
+        val expectedException = IllegalArgumentException("Article ID cannot be empty")
+        // Assuming your repository would return this for an empty ID
+        // Mock the repository to return a failure for an empty ID
+        coEvery { mockArticleRepository.getArticleById(articleId) } returns Result.failure(expectedException)
+
+        // When
+        val result = getArticleByIdUseCase(articleId)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(expectedException)
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/domain/src/test/kotlin/com/kesicollection/domain/GetArticlesUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/GetArticlesUseCaseTest.kt
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the [GetArticlesUseCase].
+ */
+package com.kesicollection.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.repository.ArticleRepository
+import com.kesicollection.test.core.fake.FakeArticles // Import your fake articles
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import java.io.IOException
+import kotlin.test.Test
+
+/**
+ * Tests for the [GetArticlesUseCase] class.
+ * This class verifies the behavior of the use case under different scenarios,
+ * such as successful data retrieval, empty data, and error conditions.
+ */
+class GetArticlesUseCaseTest {
+
+    /**
+     * A mock instance of [ArticleRepository] used to simulate repository interactions.
+     */
+    private lateinit var mockArticleRepository: ArticleRepository
+    /**
+     * The instance of [GetArticlesUseCase] being tested.
+     */
+    private lateinit var getArticlesUseCase: GetArticlesUseCase
+
+    /**
+     * Sets up the test environment before each test.
+     * Initializes the [mockArticleRepository] and [getArticlesUseCase].
+     */
+    @Before
+    fun setUp() {
+        mockArticleRepository = mockk() // Create a mock for ArticleRepository
+        getArticlesUseCase = GetArticlesUseCase(mockArticleRepository)
+    }
+
+    /**
+     * Tests that [GetArticlesUseCase.invoke] returns a [Result.success] with a list of articles
+     * when the repository successfully retrieves articles.
+     */
+    @Test
+    fun `invoke when repository returns articles successfully returns success with article list`() = runTest { // ktlint-disable annotation
+        // Given
+        val fakeArticleList = FakeArticles.items // Use your fake data
+        coEvery { mockArticleRepository.getArticles() } returns Result.success(fakeArticleList)
+
+        // When
+        val result = getArticlesUseCase()
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(fakeArticleList)
+        assertThat(result.getOrNull()).hasSize(FakeArticles.items.size)
+    }
+
+    /**
+     * Tests that [GetArticlesUseCase.invoke] returns a [Result.success] with an empty list
+     * when the repository successfully retrieves an empty list of articles.
+     */
+    @Test
+    fun `invoke when repository returns empty list successfully returns success with empty list`() = runTest { // ktlint-disable annotation
+        // Given
+        val emptyArticleList = emptyList<com.kesicollection.core.model.Article>()
+        coEvery { mockArticleRepository.getArticles() } returns Result.success(emptyArticleList)
+
+        // When
+        val result = getArticlesUseCase()
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(emptyArticleList)
+        assertThat(result.getOrNull()).isEmpty()
+    }
+
+    /**
+     * Tests that [GetArticlesUseCase.invoke] returns a [Result.failure] with the same exception
+     * when the repository returns a failure.
+     */
+    @Test
+    fun `invoke when repository returns failure returns failure with the same exception`() = runTest { // ktlint-disable annotation
+        // Given
+        val expectedException = IOException("Network error occurred")
+        coEvery { mockArticleRepository.getArticles() } returns Result.failure(expectedException)
+
+        // When
+        val result = getArticlesUseCase()
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(expectedException)
+        assertThat(result.exceptionOrNull()).isInstanceOf(IOException::class.java)
+        assertThat(result.exceptionOrNull()?.message).isEqualTo("Network error occurred")
+    }
+}

--- a/domain/src/test/kotlin/com/kesicollection/domain/GetDiscoverContentUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/GetDiscoverContentUseCaseTest.kt
@@ -1,0 +1,101 @@
+/**
+ * This file contains unit tests for the GetDiscoverContentUseCase.
+ */
+package com.kesicollection.domain
+// Necessary imports for testing, including Truth for assertions, model classes, repository, fake data, and MockK for mocking.
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.core.model.Discover
+import com.kesicollection.data.repository.DiscoverRepository
+import com.kesicollection.test.core.fake.FakeDiscover
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Test suite for [GetDiscoverContentUseCase].
+ * This class tests the behavior of the use case under various conditions, such as successful data retrieval,
+ * handling of failures (like network errors), and scenarios with empty data.
+ */
+class GetDiscoverContentUseCaseTest {
+
+    // Mocked DiscoverRepository to simulate data layer interactions.
+    private lateinit var mockDiscoverRepository: DiscoverRepository
+    // Instance of the use case being tested.
+    private lateinit var getDiscoverContentUseCase: GetDiscoverContentUseCase
+
+    /**
+     * Sets up the test environment before each test.
+     * Initializes the mock repository and the use case with the mock repository.
+     */
+    @Before
+    fun setUp() {
+        mockDiscoverRepository = mockk()
+        getDiscoverContentUseCase = GetDiscoverContentUseCase(mockDiscoverRepository)
+    }
+
+    /**
+     * Tests that the use case returns a success result with discover data
+     * when the repository successfully fetches the discover content.
+     */
+    @Test
+    fun `invoke when repository returns discover content successfully returns success with discover data`() = runTest {
+        val fakeDiscoverData = FakeDiscover.items.firstOrNull() // Arrange: Prepare fake data.
+        assertThat(fakeDiscoverData).isNotNull() // Assert that fake data is not null.
+
+        coEvery { mockDiscoverRepository.getDiscoverContent() } returns Result.success(fakeDiscoverData!!)
+
+        // When
+        val result = getDiscoverContentUseCase()
+
+        // Then
+        assertThat(result.isSuccess).isTrue() // Assert: Verify the operation was successful.
+        assertThat(result.getOrNull()).isEqualTo(fakeDiscoverData) // Assert: Verify the returned data matches the expected data.
+        assertThat(result.getOrNull()).isNotNull() // Assert: Ensure data is not null.
+    }
+
+    /**
+     * Tests that the use case returns a failure result with the same exception
+     * when the repository fails to fetch the discover content.
+     */
+    @Test
+    fun `invoke when repository returns failure returns failure with the same exception`() = runTest {
+        // Arrange: Simulate a network error.
+        val expectedException = IOException("Network error fetching discover content")
+        coEvery { mockDiscoverRepository.getDiscoverContent() } returns Result.failure(expectedException)
+
+        // When
+        val result = getDiscoverContentUseCase()
+
+        // Then
+        assertThat(result.isFailure).isTrue() // Assert: Verify the operation failed.
+        val actualException = result.exceptionOrNull() // Assert: Retrieve the exception.
+        assertThat(actualException).isEqualTo(expectedException) // Assert: Verify the exception is as expected.
+        assertThat(actualException).isInstanceOf(IOException::class.java) // Assert: Verify the type of exception.
+        assertThat(actualException?.message).isEqualTo("Network error fetching discover content") // Assert: Verify the exception message.
+    }
+
+    /**
+     * Tests that the use case handles gracefully and returns a success result with empty discover data
+     * when the repository successfully fetches 'empty' discover content.
+     */
+    @Test
+    fun `invoke when repository returns success with 'empty' discover data handles it gracefully`() = runTest {
+        // Arrange: Prepare empty discover data.
+        val emptyDiscoverData = Discover(featured = emptyList(), promotedContent = emptyList())
+        coEvery { mockDiscoverRepository.getDiscoverContent() } returns Result.success(emptyDiscoverData)
+
+        // Act: Execute the use case.
+        val result = getDiscoverContentUseCase()
+
+        // Then
+        assertThat(result.isSuccess).isTrue() // Assert: Verify the operation was successful.
+        val discoverContent = result.getOrNull() // Assert: Retrieve the content.
+        assertThat(discoverContent).isNotNull() // Assert: Ensure content is not null.
+        assertThat(discoverContent).isEqualTo(emptyDiscoverData) // Assert: Verify the content matches the empty data.
+        assertThat(discoverContent?.featured).isEmpty() // Assert: Verify 'featured' list is empty.
+        assertThat(discoverContent?.promotedContent).isEmpty() // Assert: Verify 'promotedContent' list is empty.
+    }
+}

--- a/domain/src/test/kotlin/com/kesicollection/domain/GetMarkdownAsStringTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/GetMarkdownAsStringTest.kt
@@ -1,0 +1,138 @@
+package com.kesicollection.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.repository.MarkdownRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Unit tests for the [GetMarkdownAsString] use case.
+ *
+ * This class tests the behavior of [GetMarkdownAsString] when interacting with a mocked [MarkdownRepository].
+ * It covers scenarios like successful markdown retrieval, empty markdown content, and repository failures.
+ */
+class GetMarkdownAsStringTest {
+
+    /**
+     * A mock instance of [MarkdownRepository] used to simulate repository behavior.
+     */
+    private lateinit var mockMarkdownRepository: MarkdownRepository
+
+    /**
+     * The instance of [GetMarkdownAsString] being tested.
+     */
+    private lateinit var getMarkdownAsString: GetMarkdownAsString
+
+    /**
+     * Sets up the test environment before each test case.
+     * This method initializes the [mockMarkdownRepository] and [getMarkdownAsString] instances.
+     */
+    @Before
+    fun setUp() {
+        mockMarkdownRepository = mockk()
+        getMarkdownAsString = GetMarkdownAsString(mockMarkdownRepository)
+    }
+
+    /**
+     * Tests the `invoke` method of [GetMarkdownAsString] when a valid file name is provided
+     * and the repository successfully returns the markdown content as a string.
+     *
+     * It verifies that the result is a [Result.success] and contains the expected markdown string.
+     */
+    @Test
+    fun `invoke with valid fileName when repository returns markdown successfully returns success with markdown string`() = runTest {
+        // Given
+        // A valid file name for the markdown file.
+        val fileName = "test.md"
+        val fakeMarkdownContent = "# Hello Markdown"
+        coEvery { mockMarkdownRepository.downloadAsString(fileName) } returns Result.success(fakeMarkdownContent)
+
+        // When
+        val result = getMarkdownAsString(fileName)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(fakeMarkdownContent)
+    }
+
+    /**
+     * Tests the `invoke` method of [GetMarkdownAsString] when a valid file name is provided
+     * and the repository successfully returns an empty string (representing empty markdown content).
+     *
+     * It verifies that the result is a [Result.success] and contains an empty string.
+     */
+    @Test
+    fun `invoke with valid fileName when repository returns empty string successfully returns success with empty string`() = runTest {
+        // Given
+        // A file name for an empty markdown file.
+        val fileName = "empty.md"
+        val emptyMarkdownContent = ""
+        coEvery { mockMarkdownRepository.downloadAsString(fileName) } returns Result.success(emptyMarkdownContent)
+
+        // When
+        val result = getMarkdownAsString(fileName)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(emptyMarkdownContent)
+    }
+
+    /**
+     * Tests the `invoke` method of [GetMarkdownAsString] when the repository returns a failure
+     * (e.g., due to an [IOException] during download).
+     *
+     * It verifies that the result is a [Result.failure] and contains the same exception that the repository returned.
+     */
+    @Test
+    fun `invoke when repository returns failure returns failure with the same exception`() = runTest {
+        // Given
+        // A file name that will cause a repository error.
+        val fileName = "error.md"
+        val expectedException = IOException("Failed to download markdown file")
+        coEvery { mockMarkdownRepository.downloadAsString(fileName) } returns Result.failure(expectedException)
+
+        // When
+        val result = getMarkdownAsString(fileName)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        val actualException = result.exceptionOrNull()
+        assertThat(actualException).isEqualTo(expectedException)
+        assertThat(actualException).isInstanceOf(IOException::class.java)
+        assertThat(actualException?.message).isEqualTo("Failed to download markdown file")
+    }
+
+    /**
+     * Tests the `invoke` method of [GetMarkdownAsString] when an empty file name is provided
+     * and the repository is expected to handle this by returning a failure (e.g., with an [IllegalArgumentException]).
+     *
+     * This test assumes the repository itself performs validation for empty file names.
+     * It verifies that the result is a [Result.failure] and contains the expected exception.
+     */
+    @Test
+    fun `invoke with empty fileName when repository handles it (e_g_ returns failure)`() = runTest {
+        // Given
+        // An empty file name.
+        val fileName = ""
+        // How your repository is expected to behave with an empty fileName
+        // Option 1: Repository itself validates and returns a failure
+        val expectedException = IllegalArgumentException("File name cannot be empty")
+        coEvery { mockMarkdownRepository.downloadAsString(fileName) } returns Result.failure(expectedException)
+        // Option 2: Repository throws (less common for simple passthrough use cases like this)
+        // coEvery { mockMarkdownRepository.downloadAsString(fileName) } throws IllegalArgumentException("File name cannot be empty")
+
+
+        // When
+        val result = getMarkdownAsString(fileName)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        val actualException = result.exceptionOrNull()
+        assertThat(actualException).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(actualException?.message).isEqualTo("File name cannot be empty")
+    }
+}

--- a/domain/src/test/kotlin/com/kesicollection/domain/GetPodcastByIdUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/GetPodcastByIdUseCaseTest.kt
@@ -1,0 +1,108 @@
+package com.kesicollection.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.repository.PodcastRepository
+import com.kesicollection.test.core.fake.FakePodcasts
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for the [GetPodcastByIdUseCase].
+ * This class tests the behavior of the use case when fetching a podcast by its ID.
+ */
+class GetPodcastByIdUseCaseTest {
+
+    /**
+     * Mock implementation of [PodcastRepository] used for testing.
+     */
+    private lateinit var mockPodcastRepository: PodcastRepository
+
+    /**
+     * The instance of [GetPodcastByIdUseCase] being tested.
+     */
+    private lateinit var getPodcastByIdUseCase: GetPodcastByIdUseCase
+
+    /**
+     * Sets up the test environment before each test case.
+     * Initializes the mock repository and the use case.
+     */
+    @Before
+    fun setUp() {
+        mockPodcastRepository = mockk()
+        getPodcastByIdUseCase = GetPodcastByIdUseCase(mockPodcastRepository)
+    }
+
+    /**
+     * Tests the scenario where a podcast with an existing ID is requested,
+     * and the repository successfully returns the podcast.
+     *
+     * It verifies that the use case returns a [Result.success] with the correct podcast data.
+     */
+    @Test
+    fun `invoke with existing ID when repository returns podcast successfully returns success with podcast data`() = runTest {
+        // Given
+        val fakePodcast = FakePodcasts.items.firstOrNull() // Get a podcast from fake data
+        assertThat(fakePodcast).isNotNull() // Ensure fake data exists
+        val podcastId = fakePodcast!!.id
+
+        coEvery { mockPodcastRepository.getPodcastById(podcastId) } returns Result.success(fakePodcast)
+
+        // When
+        val result = getPodcastByIdUseCase(podcastId)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(fakePodcast)
+    }
+
+    /**
+     * Tests the scenario where a podcast with a non-existent ID is requested,
+     * and the repository returns a failure.
+     *
+     * It verifies that the use case returns a [Result.failure] with the expected exception.
+     */
+    @Test
+    fun `invoke with non-existent ID when repository returns failure returns failure`() = runTest {
+        // Given
+        val podcastId = "non_existent_id"
+        val expectedException = NoSuchElementException("Podcast with ID $podcastId not found")
+        coEvery { mockPodcastRepository.getPodcastById(podcastId) } returns Result.failure(expectedException)
+
+        // When
+        val result = getPodcastByIdUseCase(podcastId)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        val actualException = result.exceptionOrNull()
+        assertThat(actualException).isEqualTo(expectedException)
+        assertThat(actualException).isInstanceOf(NoSuchElementException::class.java)
+        assertThat(actualException?.message).isEqualTo("Podcast with ID $podcastId not found")
+    }
+
+    /**
+     * Tests the scenario where an empty podcast ID is provided, and the repository
+     * (or the use case's input validation if implemented there) handles this by returning a failure.
+     * This specific test assumes the repository handles the validation.
+     *
+     * It verifies that the use case returns a [Result.failure] with an [IllegalArgumentException].
+     */
+    @Test
+    fun `invoke with empty ID when repository handles it (e_g_ returns failure)`() = runTest {
+        // Given
+        val podcastId = ""
+        val expectedException = IllegalArgumentException("Podcast ID cannot be empty")
+        coEvery { mockPodcastRepository.getPodcastById(podcastId) } returns Result.failure(expectedException)
+
+        // When
+        val result = getPodcastByIdUseCase(podcastId)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        val actualException = result.exceptionOrNull()
+        assertThat(actualException).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(actualException?.message).isEqualTo("Podcast ID cannot be empty")
+    }
+}

--- a/domain/src/test/kotlin/com/kesicollection/domain/GetPodcastsUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/GetPodcastsUseCaseTest.kt
@@ -1,0 +1,93 @@
+package com.kesicollection.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.core.model.Podcast
+import com.kesicollection.data.repository.PodcastRepository
+import com.kesicollection.test.core.fake.FakePodcasts
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Unit tests for the [GetPodcastsUseCase].
+ */
+class GetPodcastsUseCaseTest {
+
+    private lateinit var mockPodcastRepository: PodcastRepository
+    private lateinit var getPodcastsUseCase: GetPodcastsUseCase
+
+    /**
+     * Sets up the test environment before each test.
+     * Initializes the mock [PodcastRepository] and the [GetPodcastsUseCase] instance.
+     */
+    @Before
+    fun setUp() {
+        mockPodcastRepository = mockk()
+        getPodcastsUseCase = GetPodcastsUseCase(mockPodcastRepository)
+    }
+
+    /**
+     * Tests that [GetPodcastsUseCase.invoke] returns a [Result.success] with a list of podcasts
+     * when the repository returns podcasts successfully.
+     */
+    @Test
+    fun `invoke when repository returns podcasts successfully returns success with podcast list`() = runTest {
+        // Given
+        val fakePodcastList = FakePodcasts.items // Use your fake data directly
+        coEvery { mockPodcastRepository.getAllPodcasts() } returns Result.success(fakePodcastList)
+
+        // When
+        val result = getPodcastsUseCase() // UseCase invoke()
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(fakePodcastList)
+        assertThat(result.getOrNull()).hasSize(FakePodcasts.items.size)
+        if (fakePodcastList.isNotEmpty()) {
+            assertThat(result.getOrNull()?.first()).isEqualTo(fakePodcastList.first())
+        }
+    }
+
+    /**
+     * Tests that [GetPodcastsUseCase.invoke] returns a [Result.success] with an empty list
+     * when the repository returns an empty list of podcasts successfully.
+     */
+    @Test
+    fun `invoke when repository returns empty list successfully returns success with empty list`() = runTest { // ktlint-disable max-line-length
+        // Given
+        val emptyPodcastList = emptyList<Podcast>()
+        coEvery { mockPodcastRepository.getAllPodcasts() } returns Result.success(emptyPodcastList)
+
+        // When
+        val result = getPodcastsUseCase()
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(emptyPodcastList)
+        assertThat(result.getOrNull()).isEmpty()
+    }
+
+    /**
+     * Tests that [GetPodcastsUseCase.invoke] returns a [Result.failure] with the same exception
+     * when the repository returns a failure.
+     */
+    @Test
+    fun `invoke when repository returns failure returns failure with the same exception`() = runTest { // ktlint-disable max-line-length
+        // Given
+        val expectedException = IOException("Network error fetching podcasts")
+        coEvery { mockPodcastRepository.getAllPodcasts() } returns Result.failure(expectedException)
+
+        // When
+        val result = getPodcastsUseCase()
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        val actualException = result.exceptionOrNull()
+        assertThat(actualException).isEqualTo(expectedException)
+        assertThat(actualException).isInstanceOf(IOException::class.java)
+        assertThat(actualException?.message).isEqualTo("Network error fetching podcasts")
+    }
+}

--- a/domain/src/test/kotlin/com/kesicollection/domain/IsArticleBookmarkedUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/kesicollection/domain/IsArticleBookmarkedUseCaseTest.kt
@@ -1,0 +1,144 @@
+package com.kesicollection.domain
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.data.repository.BookmarkRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for the [IsArticleBookmarkedUseCase].
+ * This class tests the functionality of checking if an article is bookmarked.
+ */
+class IsArticleBookmarkedUseCaseTest {
+
+    /**
+     * A mock instance of [BookmarkRepository] used for testing.
+     */
+    private lateinit var mockBookmarkRepository: BookmarkRepository
+    /**
+     * The instance of [IsArticleBookmarkedUseCase] under test.
+     */
+    private lateinit var isArticleBookmarkedUseCase: IsArticleBookmarkedUseCase
+
+    /**
+     * Sets up the test environment before each test case.
+     * Initializes the mock repository and the use case.
+     */
+    @Before
+    fun setUp() {
+        mockBookmarkRepository = mockk()
+        isArticleBookmarkedUseCase = IsArticleBookmarkedUseCase(mockBookmarkRepository)
+    }
+
+    /**
+     * Tests that [IsArticleBookmarkedUseCase.invoke] returns `true` when the article is bookmarked.
+     */
+    @Test
+    fun `invoke when article is bookmarked returns true`() = runTest {
+        // Given
+        // An article ID that is expected to be bookmarked.
+        val articleId = "article123"
+        coEvery { mockBookmarkRepository.isBookmarked(articleId) } returns true
+
+        // When
+        val result = isArticleBookmarkedUseCase(articleId)
+
+        // Then
+        // Assert that the result is true.
+        assertThat(result).isTrue()
+    }
+
+    /**
+     * Tests that [IsArticleBookmarkedUseCase.invoke] returns `false` when the article is not bookmarked.
+     */
+    @Test
+    fun `invoke when article is not bookmarked returns false`() = runTest {
+        // Given an article ID that is expected to not be bookmarked.
+        val articleId = "article456"
+        coEvery { mockBookmarkRepository.isBookmarked(articleId) } returns false
+
+        // When
+        val result = isArticleBookmarkedUseCase(articleId)
+
+        // Then
+        // Assert that the result is false.
+        assertThat(result).isFalse()
+    }
+
+    /**
+     * Tests that [IsArticleBookmarkedUseCase.invoke] correctly identifies a bookmarked article even when other articles are not.
+     */
+    @Test
+    fun `invoke with different article ID when bookmarked returns true`() = runTest {
+        // Given two article IDs, one bookmarked and one not.
+        val articleId1 = "article_abc"
+        val articleId2 = "article_xyz"
+        coEvery { mockBookmarkRepository.isBookmarked(articleId1) } returns true
+        coEvery { mockBookmarkRepository.isBookmarked(articleId2) } returns false // To ensure specificity
+
+        // When
+        val result = isArticleBookmarkedUseCase(articleId1)
+
+        // Then
+        // Assert that the result for the bookmarked article is true.
+        assertThat(result).isTrue()
+    }
+
+    /**
+     * Tests that [IsArticleBookmarkedUseCase.invoke] correctly identifies a non-bookmarked article even when other articles are.
+     */
+    @Test
+    fun `invoke with different article ID when not bookmarked returns false`() = runTest {
+        // Given two article IDs, one not bookmarked and one bookmarked.
+        val articleId1 = "article_def"
+        val articleId2 = "article_ghi"
+        coEvery { mockBookmarkRepository.isBookmarked(articleId1) } returns false
+        coEvery { mockBookmarkRepository.isBookmarked(articleId2) } returns true // To ensure specificity
+
+        // When
+        val result = isArticleBookmarkedUseCase(articleId1)
+
+        // Then
+        // Assert that the result for the non-bookmarked article is false.
+        assertThat(result).isFalse()
+    }
+
+    /**
+     * Tests that [IsArticleBookmarkedUseCase.invoke] returns `false` for an empty article ID when it's not bookmarked (edge case).
+     */
+    @Test
+    fun `invoke with empty article ID when not bookmarked returns false`() = runTest {
+        // Given an empty article ID that is expected to not be bookmarked.
+        val articleId = "" // Testing edge case
+        coEvery { mockBookmarkRepository.isBookmarked(articleId) } returns false
+
+        // When
+        // Invoke the use case with the empty article ID.
+        val result = isArticleBookmarkedUseCase(articleId)
+
+        // Then
+        // Assert that the result is false.
+        assertThat(result).isFalse()
+    }
+
+    /**
+     * Tests that [IsArticleBookmarkedUseCase.invoke] returns `true` for an empty article ID when it is bookmarked (edge case).
+     */
+    @Test
+    fun `invoke with empty article ID when bookmarked returns true`() = runTest {
+        // Given an empty article ID that is expected to be bookmarked.
+        val articleId = "" // Testing edge case
+        coEvery { mockBookmarkRepository.isBookmarked(articleId) } returns true
+
+        // When
+        // Invoke the use case with the empty article ID.
+        val result = isArticleBookmarkedUseCase(articleId)
+
+        // Then
+        // Assert that the result is true.
+        assertThat(result).isTrue()
+    }
+}


### PR DESCRIPTION
This commit introduces unit tests for the following UseCase classes in the domain layer:

- `GetArticlesUseCase`
- `GetArticleByIdUseCase`
- `GetMarkdownAsString`
- `GetDiscoverContentUseCase`
- `BookmarkArticleByIdUseCase`
- `GetPodcastsUseCase`
- `GetPodcastByIdUseCase`
- `IsArticleBookmarkedUseCase`

The tests cover various scenarios, including:
- Successful data retrieval
- Handling of empty data
- Error conditions and exception propagation
- Edge cases like empty IDs or special characters in IDs
- Concurrent calls (for `BookmarkArticleByIdUseCase`)

Additionally, the `test.core` project is added as a test implementation dependency to `domain/build.gradle.kts` to facilitate the use of fake data in these tests.

CLOSES #105