### PR TITLE
feat(discover): Add unit tests and test tags

### DIFF
--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -90,7 +91,7 @@ fun DiscoverScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DiscoverScreen(
+internal fun DiscoverScreen(
     uiState: UiState,
     onSeeAllClick: (UICategory) -> Unit,
     onContentClick: (UIContent) -> Unit,
@@ -115,6 +116,7 @@ private fun DiscoverScreen(
                 Modifier
                     .padding(innerPadding)
                     .padding(start = 16.dp, top = 16.dp)
+                    .testTag(":feature:discover:LoadingDiscover")
             )
 
             is UiState.DiscoverContent -> DiscoverContent(
@@ -123,6 +125,7 @@ private fun DiscoverScreen(
                 onContentClick = onContentClick,
                 modifier = Modifier
                     .padding(innerPadding)
+                    .testTag(":feature:discover:DiscoverContent")
             )
 
             is UiState.Error -> {
@@ -132,6 +135,7 @@ private fun DiscoverScreen(
                         .fillMaxSize()
                         .padding(innerPadding)
                         .padding(horizontal = 16.dp)
+                        .testTag(":feature:discover:ShowError")
                 )
             }
         }
@@ -179,10 +183,12 @@ fun DiscoverContent(
     LazyColumn(
         modifier = modifier,
     ) {
-        featuredContentSection(
-            featuredContent = uiState.featuredContent,
-            onContentClick = onFeatureContentClick
-        )
+        if (uiState.featuredContent.isNotEmpty()) {
+            featuredContentSection(
+                featuredContent = uiState.featuredContent,
+                onContentClick = onFeatureContentClick
+            )
+        }
         promotedContentSections(
             promotedContent = uiState.promotedContent,
             onSeeAllClick = rememberedOnSeeAllClick,

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/FeatureContentSection.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/FeatureContentSection.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,6 +54,7 @@ fun LazyListScope.featuredContentSection(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
             )
             LazyRow(
+                modifier = featuredLazyRowModifier,
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
@@ -71,6 +73,9 @@ fun LazyListScope.featuredContentSection(
 val featuredModifier = Modifier
     .size(320.dp)
     .clip(RoundedCornerShape(8.dp))
+
+val featuredLazyRowModifier = Modifier
+    .testTag(":feature:discover:featuredLazyRow")
 
 @Composable
 fun FeaturedCard(

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/PromotedContentSection.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/PromotedContentSection.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -56,48 +57,61 @@ fun LazyListScope.promotedContentSections(
     onSeeAllClick: (UICategory) -> Unit = {},
 ) {
     promotedContent.forEach { (category, contentList) ->
-        item {
-            val rememberedOnSeeAllClick = remember { { onSeeAllClick(category) } }
+        if (contentList.isNotEmpty()) {
+            item {
+                val rememberedOnSeeAllClick = remember { { onSeeAllClick(category) } }
 
-            Column(
-                modifier = modifier
-                    .padding(bottom = 16.dp)
-                    .fillParentMaxWidth(),
-            ) {
-                Row(
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    modifier = Modifier.fillParentMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                Column(
+                    modifier = modifier
+                        .padding(bottom = 16.dp)
+                        .fillParentMaxWidth(),
                 ) {
-                    Text(
-                        text = category.name,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(
-                            horizontal = 16.dp,
-                            vertical = 8.dp
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier.fillParentMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = category.name,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier
+                                .padding(
+                                    horizontal = 16.dp,
+                                    vertical = 8.dp
+                                )
                         )
-                    )
-                    TextButton(onClick = rememberedOnSeeAllClick) {
-                        Text(text = stringResource(R.string.feature_discover_see_all))
+                        TextButton(
+                            onClick = rememberedOnSeeAllClick,
+                            modifier = seeAllButtonModifier
+                        ) {
+                            Text(text = stringResource(R.string.feature_discover_see_all))
+                        }
                     }
-                }
-                LazyRow(
-                    contentPadding = PaddingValues(horizontal = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    items(contentList) { content ->
-                        PromotedCard(
-                            uiContent = content,
-                            onContentClick = onContentClick
-                        )
+                    LazyRow(
+                        modifier = promotedLazyRowModifier,
+                        contentPadding = PaddingValues(horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(contentList) { content ->
+                            PromotedCard(
+                                uiContent = content,
+                                onContentClick = onContentClick
+                            )
+                        }
                     }
                 }
             }
         }
     }
 }
+
+private val promotedLazyRowModifier = Modifier
+    .testTag(":feature:discover:promotedLazyRowModifier")
+
+private val seeAllButtonModifier = Modifier
+    .testTag(":feature:discover:seeAllButton")
 
 @Composable
 fun PromotedCard(

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/DiscoverContentTest.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/DiscoverContentTest.kt
@@ -1,0 +1,177 @@
+package com.kesicollection.feature.discover
+
+import android.os.Build
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import coil3.ImageLoader
+import coil3.annotation.ExperimentalCoilApi
+import com.kesicollection.core.app.AppManager
+import com.kesicollection.core.uisystem.LocalApp
+import com.kesicollection.core.uisystem.LocalImageLoader
+import com.kesicollection.core.uisystem.theme.KesiTheme
+import com.kesicollection.feature.discover.fake.FakePromotedContent
+import com.kesicollection.feature.discover.fake.FakeUIContent
+import com.kesicollection.feature.discover.utils.OnContentInvoker
+import com.kesicollection.feature.discover.utils.OnSeeAllInvoker
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoilApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.M, Build.VERSION_CODES.TIRAMISU]) // API 23 and 33
+class DiscoverContentTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val appManager: AppManager = mockk(relaxed = true)
+    private val mockOnSeeAllClick: OnSeeAllInvoker = mockk(relaxed = true)
+    private val mockOnContentClick: OnContentInvoker = mockk(relaxed = true)
+
+    private fun setDiscoverContent(uiState: UiState.DiscoverContent) {
+        composeTestRule.setContent {
+            KesiTheme {
+                // Image loader for preview.
+                val imageLoader = ImageLoader.Builder(LocalContext.current)
+                    .build()
+
+                CompositionLocalProvider(LocalImageLoader provides imageLoader) {
+                    CompositionLocalProvider(LocalApp provides appManager) {
+                        DiscoverContent(
+                            uiState = uiState,
+                            onSeeAllClick = mockOnSeeAllClick::invoke,
+                            onContentClick = mockOnContentClick::invoke,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `DiscoverContent displays featured content correctly`() {
+        val testUiState = UiState.DiscoverContent(
+            featuredContent = FakeUIContent.items,
+            promotedContent = FakePromotedContent.items
+        )
+
+        setDiscoverContent(testUiState)
+
+        // Assert that featured content items are displayed
+        composeTestRule.onNodeWithText(FakeUIContent.items.first().title).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(":feature:discover:featuredLazyRow")
+            .performScrollToNode(hasText(FakeUIContent.items.last().title))
+        composeTestRule.onNodeWithText(FakeUIContent.items.last().title).assertIsDisplayed()
+    }
+
+    @Test
+    fun `DiscoverContent displays promoted content correctly`() {
+        val testUiState = UiState.DiscoverContent(
+            featuredContent = FakeUIContent.items,
+            promotedContent = FakePromotedContent.items
+        )
+
+        setDiscoverContent(testUiState)
+
+        val firstSection = FakePromotedContent.items[FakePromotedContent.items.keys.first()]!!
+
+        // Assert that promoted category and content are displayed
+        composeTestRule.onNodeWithText(firstSection.first().title).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(":feature:discover:promotedLazyRowModifier")
+            .performScrollToNode(hasText(firstSection.last().title))
+        composeTestRule.onNodeWithText(firstSection.last().title).assertIsDisplayed()
+    }
+
+    @Test
+    fun `DiscoverContent calls onContentClick for featured item and logs analytics`() {
+        val testUiState = UiState.DiscoverContent(
+            featuredContent = FakeUIContent.items,
+            promotedContent = FakePromotedContent.items
+        )
+        setDiscoverContent(testUiState)
+        composeTestRule.onNodeWithText(FakeUIContent.items.first().title).performClick()
+
+        // Verify that the onContentClick callback was invoked with the correct item
+        verify { mockOnContentClick(FakeUIContent.items.first()) }
+
+        //For now we will validate that "logEvent" is called only but in the integration tests we have to
+        //verify actual parameters since they depend in DI
+        verify(exactly = 1) { appManager.analytics.logEvent(any(), any()) }
+    }
+
+    @Test
+    fun `DiscoverContent calls onSeeAllClick for promoted category and logs analytics`() {
+        val testUiState = UiState.DiscoverContent(
+            featuredContent = FakeUIContent.items,
+            promotedContent = FakePromotedContent.items
+        )
+
+        setDiscoverContent(testUiState)
+
+        composeTestRule.onAllNodesWithTag(":feature:discover:seeAllButton")[0]
+            .performClick()
+
+        verify { mockOnSeeAllClick(FakePromotedContent.items.keys.first()) }
+
+        //For now we will validate that "logEvent" is called only but in the integration tests we have to
+        //verify actual parameters since they depend in DI
+        verify(exactly = 1) { appManager.analytics.logEvent(any(), any()) }
+    }
+
+    @Test
+    fun `DiscoverContent displays correctly when featured content is empty`() {
+        val testUiState = UiState.DiscoverContent(
+            featuredContent = persistentListOf(),
+            promotedContent = FakePromotedContent.items
+        )
+
+        setDiscoverContent(testUiState)
+
+        composeTestRule.onNodeWithTag(":feature:discover:featuredLazyRow").assertDoesNotExist()
+        composeTestRule.onNodeWithText(FakeUIContent.items.first().title).assertDoesNotExist()
+
+        val firstPromotedCategory = FakePromotedContent.items.keys.first()
+        val firstPromotedItemInFirstCategory =
+            FakePromotedContent.items[firstPromotedCategory]!!.first()
+
+        composeTestRule.onNodeWithText(firstPromotedCategory.name)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(firstPromotedItemInFirstCategory.title)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `DiscoverContent displays correctly when promoted content is empty`() {
+        val testUiState = UiState.DiscoverContent(
+            featuredContent = FakeUIContent.items,
+            promotedContent = persistentMapOf()
+        )
+
+        setDiscoverContent(testUiState)
+
+        // Assert featured content is still displayed
+        composeTestRule.onNodeWithText(FakeUIContent.items.first().title).assertIsDisplayed()
+
+        // Assert promoted content section is not displayed
+        composeTestRule.onNodeWithTag(":feature:discover:promotedLazyRowModifier")
+            .assertDoesNotExist()
+        // Try to find a promoted category name - should not exist
+        val firstPromotedCategory = FakePromotedContent.items.keys.first()
+        composeTestRule.onNodeWithText(firstPromotedCategory.name).assertDoesNotExist()
+    }
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/DiscoverViewModelTest.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/DiscoverViewModelTest.kt
@@ -1,0 +1,109 @@
+package com.kesicollection.feature.discover
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.core.app.IntentProcessor
+import com.kesicollection.core.app.IntentProcessorFactory
+import com.kesicollection.core.app.Reducer
+import com.kesicollection.feature.discover.fake.FakePromotedContent
+import com.kesicollection.feature.discover.fake.FakeUIContent
+import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [DiscoverViewModel].
+ *
+ * This test suite verifies the behavior of the [DiscoverViewModel] under various conditions.
+ * It focuses on:
+ *
+ * 1.  **Initial UI State**: Ensures that the ViewModel initializes with the correct loading state.
+ * 2.  **Intent Processing and State Updates**:
+ *     *   Verifies that when an intent (e.g., `FetchFeatureItems`) is sent to the ViewModel,
+ *         the `IntentProcessor` is correctly invoked.
+ *     *   Ensures that the `IntentProcessor`'s resulting state update (simulated via a callback
+ *         and a reducer function) is correctly reflected in the ViewModel's `uiState` Flow.
+ */
+class DiscoverViewModelTest {
+
+    // Test dispatcher for coroutines
+    private val testDispatcher = StandardTestDispatcher()
+
+    // Mocks
+    private lateinit var intentProcessorFactory: IntentProcessorFactory<UiState, Intent>
+    private lateinit var intentProcessor: IntentProcessor<UiState>
+
+    // Mock UiState flow for the intent processor
+    private lateinit var mockUiStateFlow: MutableStateFlow<UiState>
+
+    // ViewModel instance
+    private lateinit var viewModel: DiscoverViewModel
+
+    @Before
+    fun setUp() {
+
+        // Initialize mocks
+        intentProcessorFactory = mockk()
+        intentProcessor = mockk(relaxed = true) // relaxed = true to ignore void functions
+
+        // Initialize mockUiStateFlow with the initial state
+        mockUiStateFlow = MutableStateFlow(UiState.Loading)
+
+        // Stub the create method of the factory to return our mock processor
+        every { intentProcessorFactory.create(any()) } returns intentProcessor
+        // Stub the processIntent method of the processor to update the mockUiStateFlow
+        coEvery { intentProcessor.processIntent(any()) } coAnswers {
+            mockUiStateFlow.update { arg(1) }
+        }
+
+        // Initialize ViewModel
+        viewModel = DiscoverViewModel(testDispatcher, intentProcessorFactory)
+    }
+
+    @Test
+    fun `Initial UI state verification`() = runTest {
+        assertThat(viewModel.uiState.first()).isEqualTo(UiState.Loading)
+    }
+
+    @Test
+    fun `Send single intent and verify UI state update`() = runTest {
+        val testIntent = Intent.FetchFeatureItems
+        val expectedState = UiState.DiscoverContent(
+            featuredContent = FakeUIContent.items,
+            promotedContent = FakePromotedContent.items
+        )
+
+        // This will hold the (Reducer<UiState>) -> Unit function that the ViewModel passes
+        // to processor.processIntent()
+        val reducerCallbackSlot = slot<(Reducer<UiState>) -> Unit>()
+
+        // 1. Configure the mockProcessor:
+        //    When mockProcessor.processIntent(...) is called by the ViewModel,
+        //    we capture the callback.
+        //    Then, we simulate the processor doing its work and invoking that callback
+        //    with a function that produces the `expectedState`.
+        coEvery { intentProcessor.processIntent(capture(reducerCallbackSlot)) } coAnswers {
+            // Simulate the processor having done its work and now providing the
+            // state transformation function (Reducer<UiState>) to the callback.
+            // This Reducer<UiState> is: ` { expectedState } `
+            // which means "current state becomes expectedState".
+            val stateTransform: Reducer<UiState> = { expectedState }
+            reducerCallbackSlot.captured.invoke(stateTransform)
+        }
+
+        // Act: Send the intent.
+        viewModel.sendIntent(testIntent)
+
+        // Assert: Advance dispatcher and check state.
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value).isEqualTo(expectedState)
+    }
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/StatefulDiscoverScreenTest.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/StatefulDiscoverScreenTest.kt
@@ -1,0 +1,247 @@
+package com.kesicollection.feature.discover
+
+import android.os.Build
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import coil3.ImageLoader
+import coil3.annotation.ExperimentalCoilApi
+import com.kesicollection.core.app.AppManager
+import com.kesicollection.core.model.ErrorState
+import com.kesicollection.core.uisystem.LocalApp
+import com.kesicollection.core.uisystem.LocalImageLoader
+import com.kesicollection.feature.discover.utils.OnContentInvoker
+import com.kesicollection.feature.discover.utils.OnRetryInvoker
+import com.kesicollection.feature.discover.utils.OnSeeAllInvoker
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+/**
+ * Test suite for [DiscoverScreen] which is a stateful composable.
+ * This class focuses on testing the UI behavior based on different [UiState] values
+ * and interactions with the screen.
+ *
+ * Tests cover:
+ * - Display of Loading state.
+ * - Display of Content state.
+ * - Display of Error state.
+ * - Invocation of `onContentClick` callback when a content item is clicked.
+ * - Invocation of `onSeeAllClick` callback when a "See All" button is clicked.
+ * - Invocation of ViewModel's `sendIntent` when "Try Again" is clicked in Error state.
+ * - Logging of analytics screen view event on composition.
+ */
+
+@OptIn(ExperimentalCoilApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU]) // Using a single SDK for simplicity here
+class StatefulDiscoverScreenTest {
+    /**
+     * Rule for managing and interacting with Compose UI components in tests.
+     */
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // Mocks for dependencies of DiscoverScreen
+    /**
+     * Mocked [DiscoverViewModel] to control its state and verify interactions.
+     */
+    private lateinit var mockViewModel: DiscoverViewModel
+    /**
+     * Mocked [AppManager] to verify analytics events.
+     */
+    private lateinit var appManager: AppManager
+    /**
+     * Mocked callback for "See All" clicks.
+     */
+    private lateinit var mockOnSeeAllClick: OnSeeAllInvoker
+    private lateinit var mockOnContentClick: OnContentInvoker
+    private lateinit var mockOnTryAgain: OnRetryInvoker
+
+    // StateFlow to control the ViewModel's state in tests
+    private lateinit var uiStateFlow: MutableStateFlow<UiState>
+
+    /**
+     * Sets up the test environment before each test case.
+     */
+    @Before
+    fun setUp() {
+        uiStateFlow = MutableStateFlow(UiState.Loading) // Initial state for tests
+        appManager = mockk(relaxed = true)
+        mockOnSeeAllClick = mockk(relaxed = true)
+        mockOnContentClick = mockk(relaxed = true)
+        mockOnTryAgain = mockk(relaxed = true)
+        mockViewModel = mockk {
+            every { uiState } returns uiStateFlow
+            every { sendIntent(any()) } just Runs // Mock sendIntent if it's called
+        }
+    }
+
+    /**
+     * Helper function to set the content of the test rule with [DiscoverScreen]
+     * and necessary CompositionLocalProviders.
+     */
+    private fun setStatefulDiscoverScreen() {
+        composeTestRule.setContent {
+            // Image loader for preview.
+            val imageLoader = ImageLoader.Builder(LocalContext.current)
+                .build()
+
+            CompositionLocalProvider(LocalImageLoader provides imageLoader) {
+                CompositionLocalProvider(LocalApp provides appManager) {
+                    DiscoverScreen(
+                        viewModel = mockViewModel,
+                        onSeeAllClick = mockOnSeeAllClick::invoke,
+                        onContentClick = mockOnContentClick::invoke
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Verifies that the loading indicator is displayed when the [UiState] is `Loading`.
+     * It also ensures that content and error views are not present.
+     */
+    @Test
+    fun `when state is Loading, LoadingDiscover is displayed`() {
+        uiStateFlow.value = UiState.Loading
+        setStatefulDiscoverScreen()
+
+        composeTestRule.onNodeWithTag(":feature:discover:LoadingDiscover").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(":feature:discover:DiscoverContent", useUnmergedTree = true)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithTag(":feature:discover:ShowError", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    /**
+     * Verifies that the discover content is displayed when the [UiState] is `DiscoverContent`.
+     * It also checks for the visibility of specific content items and ensures that loading
+     * and error views are not present.
+     */
+    @Test
+    fun `when state is DiscoverContent, DiscoverContent is displayed`() {
+        val testContent = contentSample // From DiscoverScreen.kt previews
+        uiStateFlow.value = testContent
+        setStatefulDiscoverScreen()
+
+        composeTestRule.onNodeWithTag(":feature:discover:DiscoverContent").assertIsDisplayed()
+        // Optionally, assert specific content items are visible
+        composeTestRule.onNodeWithText(testContent.featuredContent.first().title)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithTag(":feature:discover:LoadingDiscover", useUnmergedTree = true)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithTag(":feature:discover:ShowError", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    /**
+     * Verifies that the error view is displayed when the [UiState] is `Error`.
+     * It also ensures that loading and content views are not present.
+     */
+    @Test
+    fun `when state is Error, ShowError is displayed`() {
+        uiStateFlow.value = UiState.Error(ErrorState(DiscoverErrors.NetworkError))
+        setStatefulDiscoverScreen()
+
+        composeTestRule.onNodeWithTag(":feature:discover:ShowError").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(":feature:discover:LoadingDiscover", useUnmergedTree = true)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithTag(":feature:discover:DiscoverContent", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    /**
+     * Verifies that the `onContentClick` callback is invoked with the correct data
+     * when a content item is clicked. It also checks if an analytics event is logged.
+     */
+    @Test
+    fun `when content item is clicked, onContentClick is called with correct data`() {
+        val testContentState = contentSample
+        val firstFeaturedItem = testContentState.featuredContent.first()
+        uiStateFlow.value = testContentState
+        setStatefulDiscoverScreen()
+
+        // Find the specific content item and click it.
+        // You might need more specific finders if titles are not unique.
+        // Using a testTag on individual items in your actual Composable is best.
+        composeTestRule.onNodeWithText(firstFeaturedItem.title, useUnmergedTree = true)
+            .performClick()
+
+        verify { mockOnContentClick.invoke(firstFeaturedItem) }
+        // Verify analytics event (if directly logged by the clickable modifier,
+        // or ensure the remembered lambda in DiscoverContent is correctly structured)
+        verify {
+            appManager.analytics.logEvent(any(), any())
+        }
+    }
+
+    /**
+     * Verifies that the `onSeeAllClick` callback is invoked with the correct category
+     * when a "See All" button is clicked. It also checks if an analytics event is logged.
+     */
+    @Test
+    fun `when See All is clicked, onSeeAllClick is called with correct category`() {
+        val testContentState = contentSample
+        val firstCategory = testContentState.promotedContent.keys.first()
+        uiStateFlow.value = testContentState
+        setStatefulDiscoverScreen()
+
+        composeTestRule.onAllNodesWithTag(":feature:discover:seeAllButton")[0]
+            .performClick()
+
+        verify { mockOnSeeAllClick(firstCategory) }
+        verify { appManager.analytics.logEvent(any(), any()) }
+    }
+
+    /**
+     * Verifies that the ViewModel's `sendIntent` method is called with `Intent.FetchFeatureItems`
+     * when the "Try Again" button is clicked in the error state. It also checks if an analytics
+     * event is logged.
+     */
+    @Test
+    fun `when state is Error and Try Again is clicked, ViewModel's sendIntent is called`() {
+        uiStateFlow.value = UiState.Error(ErrorState(DiscoverErrors.GenericError))
+        setStatefulDiscoverScreen()
+
+        // Find the "Try Again" button (assuming it has this text or a specific testTag)
+        composeTestRule.onNodeWithText("Try Again", ignoreCase = true).performClick()
+
+        // Verify that the ViewModel's intent to refetch is sent
+        verify { mockViewModel.sendIntent(Intent.FetchFeatureItems) }
+        verify {
+            appManager.analytics.logEvent(any(), any())
+        }
+    }
+
+    /**
+     * Verifies that an analytics screen view event is logged when the [DiscoverScreen]
+     * is composed.
+     */
+    @Test
+    fun `analytics screenView is logged on composition`() {
+        uiStateFlow.value = UiState.Loading // Any initial state will do
+        setStatefulDiscoverScreen() // Composition happens here
+
+        // SideEffect runs after successful composition
+        composeTestRule.waitForIdle() // Ensure SideEffect has a chance to run
+
+        verify {
+            appManager.analytics.logEvent(any(), any())
+        }
+    }
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/StatelessDiscoverScreenTest.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/StatelessDiscoverScreenTest.kt
@@ -1,0 +1,99 @@
+package com.kesicollection.feature.discover
+
+import android.os.Build
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import coil3.ImageLoader
+import coil3.annotation.ExperimentalCoilApi
+import com.kesicollection.core.app.AppManager
+import com.kesicollection.core.model.ErrorState
+import com.kesicollection.core.uisystem.LocalApp
+import com.kesicollection.core.uisystem.LocalImageLoader
+import com.kesicollection.core.uisystem.theme.KesiTheme
+import com.kesicollection.feature.discover.fake.FakePromotedContent
+import com.kesicollection.feature.discover.fake.FakeUIContent
+import com.kesicollection.feature.discover.utils.OnContentInvoker
+import com.kesicollection.feature.discover.utils.OnRetryInvoker
+import com.kesicollection.feature.discover.utils.OnSeeAllInvoker
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoilApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.M, Build.VERSION_CODES.TIRAMISU]) // API 23 and 33
+class StatelessDiscoverScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val appManager: AppManager = mockk(relaxed = true)
+    private val mockOnSeeAllClick: OnSeeAllInvoker = mockk(relaxed = true)
+    private val mockOnContentClick: OnContentInvoker = mockk(relaxed = true)
+    private val mockOnTryAgain: OnRetryInvoker = mockk(relaxed = true)
+
+    private fun setStatelessDiscoverScreen(uiState: UiState) {
+        composeTestRule.setContent {
+            KesiTheme { // Apply your theme
+                // Image loader for preview.
+                val imageLoader = ImageLoader.Builder(LocalContext.current)
+                    .build()
+
+                CompositionLocalProvider(LocalImageLoader provides imageLoader) {
+                    CompositionLocalProvider(LocalApp provides appManager) {
+                        DiscoverScreen(
+                            uiState = uiState,
+                            onSeeAllClick = mockOnSeeAllClick::invoke,
+                            onContentClick = mockOnContentClick::invoke,
+                            onTryAgain = mockOnTryAgain::invoke
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Display loading component when UiState is Loading`() {
+        val uiState = UiState.Loading
+        setStatelessDiscoverScreen(uiState)
+        composeTestRule.onNodeWithTag(":feature:discover:LoadingDiscover").assertExists()
+        composeTestRule.onNodeWithTag(":feature:discover:DiscoverContent").assertDoesNotExist()
+        composeTestRule.onNodeWithTag(":feature:discover:ShowError").assertDoesNotExist()
+    }
+
+    @Test
+    fun `Display DiscoverContent when UiState is DiscoverContent`() {
+        val uiState = UiState.DiscoverContent(
+            featuredContent = FakeUIContent.items,
+            promotedContent = FakePromotedContent.items
+        )
+        setStatelessDiscoverScreen(uiState)
+        composeTestRule.onNodeWithTag(":feature:discover:LoadingDiscover").assertDoesNotExist()
+        composeTestRule.onNodeWithTag(":feature:discover:DiscoverContent").assertExists()
+        composeTestRule.onNodeWithTag(":feature:discover:ShowError").assertDoesNotExist()
+
+        // Verify category names are displayed
+        composeTestRule.onNodeWithText(FakeUIContent.items.first().title).assertIsDisplayed()
+        val firstSection = FakePromotedContent.items[FakePromotedContent.items.keys.first()]!!
+
+        // Assert that promoted category and content are displayed
+        composeTestRule.onNodeWithText(FakePromotedContent.items.keys.first().name).assertIsDisplayed()
+    }
+
+    @Test
+    fun `Display ShowError when UiState is Error`() {
+        val uiState = UiState.Error(error = ErrorState(DiscoverErrors.GenericError))
+        setStatelessDiscoverScreen(uiState)
+        composeTestRule.onNodeWithTag(":feature:discover:LoadingDiscover").assertDoesNotExist()
+        composeTestRule.onNodeWithTag(":feature:discover:DiscoverContent").assertDoesNotExist()
+        composeTestRule.onNodeWithTag(":feature:discover:ShowError").assertExists()
+    }
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/fake/FakePromotedContent.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/fake/FakePromotedContent.kt
@@ -1,0 +1,32 @@
+package com.kesicollection.feature.discover.fake
+
+import com.kesicollection.core.model.ContentType // Assuming ContentType is in this package
+import com.kesicollection.feature.discover.UICategory
+import com.kesicollection.feature.discover.UIContent
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+
+object FakePromotedContent {
+    val items = persistentMapOf(
+        UICategory("category_1", "Category 1") to createFakeUIContentList(1, 5),
+        UICategory("category_2", "Category 2") to createFakeUIContentList(2, 6),
+        UICategory("category_3", "Category 3") to createFakeUIContentList(3, 5)
+    )
+}
+
+private fun createFakeUIContentList(categoryNumber: Int, numberOfItems: Int): ImmutableList<UIContent> {
+    return persistentListOf<UIContent>().builder().apply {
+        repeat(numberOfItems) { itemIndex ->
+            add(
+                UIContent(
+                    id = "cat${categoryNumber}_content_${itemIndex + 1}",
+                    img = "image_cat${categoryNumber}_${itemIndex + 1}.png",
+                    type = ContentType.entries.toTypedArray().random(),
+                    title = "Title for Content ${itemIndex + 1} in Category $categoryNumber",
+                    description = "Description for content ${itemIndex + 1} of category $categoryNumber. Lorem ipsum dolor sit amet."
+                )
+            )
+        }
+    }.build()
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/fake/FakeUIContent.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/fake/FakeUIContent.kt
@@ -1,0 +1,80 @@
+package com.kesicollection.feature.discover.fake
+
+import com.kesicollection.core.model.ContentType
+import com.kesicollection.feature.discover.UIContent
+import kotlinx.collections.immutable.persistentListOf
+
+object FakeUIContent {
+    val items = persistentListOf(
+        UIContent(
+            id = "1",
+            img = "jetpack_compose.png",
+            type = ContentType.Article,
+            title = "Exploring Jetpack Compose",
+            description = "A deep dive into the modern UI toolkit for Android."
+        ),
+        UIContent(
+            id = "2",
+            img = "kmp_podcast.png",
+            type = ContentType.Podcast,
+            title = "The Future of Kotlin Multiplatform",
+            description = "Listen to experts discuss KMP's potential."
+        ),
+        UIContent(
+            id = "3",
+            img = "accessibility_video.png",
+            type = ContentType.Video,
+            title = "Building Accessible Android Apps",
+            description = "Learn how to make your apps usable by everyone."
+        ),
+        UIContent(
+            id = "4",
+            img = "android_studio_demo.png",
+            type = ContentType.Demo,
+            title = "Android Studio Tips and Tricks",
+            description = "A quick demo of useful IDE features."
+        ),
+        UIContent(
+            id = "5",
+            img = "coroutines_article.png",
+            type = ContentType.Article,
+            title = "Mastering Coroutines in Kotlin",
+            description = "An in-depth article on asynchronous programming."
+        ),
+        UIContent(
+            id = "6",
+            img = "performance_podcast.png",
+            type = ContentType.Podcast,
+            title = "Android Performance Patterns",
+            description = "Podcast episode covering best practices for app performance."
+        ),
+        UIContent(
+            id = "7",
+            img = "material_you_video.png",
+            type = ContentType.Video,
+            title = "Introduction to Material Design 3",
+            description = "Video tutorial on implementing Material You."
+        ),
+        UIContent(
+            id = "8",
+            img = "offline_first_demo.png",
+            type = ContentType.Demo,
+            title = "Offline First App Demo",
+            description = "Showcasing strategies for building offline-capable apps."
+        ),
+        UIContent(
+            id = "9",
+            img = "android_testing.png",
+            type = ContentType.Article,
+            title = "Testing in Android: A Comprehensive Guide",
+            description = "An article covering unit, integration, and UI testing."
+        ),
+        UIContent(
+            id = "10",
+            img = "android_14_podcast.png",
+            type = ContentType.Podcast,
+            title = "What's New in Android 14",
+            description = "A podcast discussing the latest Android features."
+        )
+    )
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/intentprocessor/DefaultIntentProcessorFactoryTest.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/intentprocessor/DefaultIntentProcessorFactoryTest.kt
@@ -1,0 +1,64 @@
+package com.kesicollection.feature.discover.intentprocessor
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.core.app.CrashlyticsWrapper
+import com.kesicollection.domain.GetDiscoverContentUseCase
+import com.kesicollection.feature.discover.Intent
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [DefaultIntentProcessorFactory].
+ *
+ * This class tests the following:
+ * - [DefaultIntentProcessorFactory.create] with [Intent.FetchFeatureItems] returns an instance of [FetchFeatureItemsIntentProcessor].
+ * - The returned [FetchFeatureItemsIntentProcessor] is correctly initialized with the provided dependencies ([GetDiscoverContentUseCase] and [CrashlyticsWrapper]).
+ */
+class DefaultIntentProcessorFactoryTest {
+
+    /**
+     * Mocked instance of [GetDiscoverContentUseCase].
+     */
+    private lateinit var getDiscoverContentUseCase: GetDiscoverContentUseCase
+    /**
+     * Mocked instance of [CrashlyticsWrapper].
+     * `relaxed = true` is used to avoid stubbing every method, as we are only interested in verifying its presence.
+     */
+    private lateinit var crashlyticsWrapper: CrashlyticsWrapper
+    /**
+     * Instance of [DefaultIntentProcessorFactory] under test.
+     */
+    private lateinit var factory: DefaultIntentProcessorFactory
+
+    /**
+     * Sets up the test environment before each test.
+     * Initializes the mocks and the factory instance.
+     */
+    @Before
+    fun setUp() {
+        getDiscoverContentUseCase = mockk()
+        crashlyticsWrapper = mockk(relaxed = true) // relaxed = true to avoid stubbing every method
+        factory = DefaultIntentProcessorFactory(getDiscoverContentUseCase, crashlyticsWrapper)
+    }
+
+    /**
+     * Tests that when [DefaultIntentProcessorFactory.create] is called with an [Intent.FetchFeatureItems],
+     * it returns an instance of [FetchFeatureItemsIntentProcessor].
+     * It also verifies that the returned processor is initialized with the correct dependencies.
+     */
+    @Test
+    fun `create with FetchFeatureItems intent returns FetchFeatureItemsIntentProcessor`() {
+        // Given
+        val intent = Intent.FetchFeatureItems
+
+        // When
+        val processor = factory.create(intent)
+
+        // Then
+        assertThat(processor).isInstanceOf(FetchFeatureItemsIntentProcessor::class.java)
+        val fetchProcessor = processor as FetchFeatureItemsIntentProcessor
+        assertThat(fetchProcessor.getDiscoverContentUseCase).isEqualTo(getDiscoverContentUseCase)
+        assertThat(fetchProcessor.crashlyticsWrapper).isEqualTo(crashlyticsWrapper)
+    }
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/intentprocessor/FetchFeatureItemsIntentProcessorTest.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/intentprocessor/FetchFeatureItemsIntentProcessorTest.kt
@@ -1,0 +1,235 @@
+package com.kesicollection.feature.discover.intentprocessor
+
+import com.google.common.truth.Truth.assertThat
+import com.kesicollection.core.app.CrashlyticsWrapper
+import com.kesicollection.core.app.Reducer
+import com.kesicollection.core.model.Discover
+import com.kesicollection.core.model.ErrorState
+import com.kesicollection.domain.GetDiscoverContentUseCase
+import com.kesicollection.feature.discover.DiscoverErrors
+import com.kesicollection.feature.discover.UiState
+import com.kesicollection.feature.discover.asDiscoverContent
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [FetchFeatureItemsIntentProcessor].
+ *
+ * This test suite verifies the behavior of the `FetchFeatureItemsIntentProcessor` under various conditions,
+ * ensuring it correctly handles:
+ * - **Successful content fetching:**
+ *     - Verifies that the UI state is correctly updated with the fetched content.
+ *     - Ensures the `GetDiscoverContentUseCase` is called exactly once.
+ *     - Confirms Crashlytics is not invoked.
+ *     - Tests the case where the use case returns an empty but successful result.
+ * - **Error handling (generic exceptions):**
+ *     - Verifies that the UI state is updated to reflect a generic error.
+ *     - Ensures the error message from the exception is propagated to the UI state.
+ *     - Confirms the `GetDiscoverContentUseCase` is called exactly once.
+ *     - Verifies that Crashlytics is called with the correct exception and parameters.
+ *     - Tests the scenario where the exception message is null.
+ * - **Error handling (CancellationException):**
+ *     - Verifies that the reducer is not called when a `CancellationException` occurs.
+ *     - Ensures the `GetDiscoverContentUseCase` is called exactly once.
+ *     - Confirms Crashlytics is not invoked for `CancellationException`.
+ *     - Tests coroutine cancellation during the execution of the `getDiscoverContentUseCase`.
+ * - **Reducer invocation:**
+ *     - Ensures the reducer is invoked exactly once upon successful content fetching.
+ *     - Ensures the reducer is invoked exactly once when a generic error occurs.
+ */
+@ExperimentalCoroutinesApi
+class FetchFeatureItemsIntentProcessorTest {
+
+    private lateinit var getDiscoverContentUseCase: GetDiscoverContentUseCase
+    private lateinit var crashlyticsWrapper: CrashlyticsWrapper
+    private lateinit var crashlyticsParams: CrashlyticsWrapper.Params
+    private lateinit var processor: FetchFeatureItemsIntentProcessor
+
+    @Before
+    fun setUp() {
+        getDiscoverContentUseCase = mockk()
+        crashlyticsWrapper = mockk(relaxed = true) // relaxed = true to avoid mocking every call
+        crashlyticsParams = mockk()
+        every { crashlyticsWrapper.params } returns crashlyticsParams
+        every { crashlyticsParams.screenName } returns "DiscoverScreen"
+        every { crashlyticsParams.className } returns "FetchFeatureItemsIntentProcessor"
+        every { crashlyticsParams.action } returns "fetch"
+
+        processor = FetchFeatureItemsIntentProcessor(getDiscoverContentUseCase, crashlyticsWrapper)
+    }
+
+    @Test
+    fun `Successful content fetch and UI update`() = runTest {
+        val mockDiscover = Discover(emptyList(), emptyList()) // Assuming Discover has a constructor
+        val expectedUiState = mockDiscover.asDiscoverContent()
+        coEvery { getDiscoverContentUseCase() } returns Result.success(mockDiscover)
+
+        val reducerSlot = slot<Reducer<UiState>>()
+        processor.processIntent { reducer -> reducerSlot.captured = reducer }
+
+        val actualUiState =
+            reducerSlot.captured.invoke(mockk(relaxed = true)) // pass a dummy state if needed
+
+        assertThat(actualUiState).isEqualTo(expectedUiState)
+        coVerify(exactly = 1) { getDiscoverContentUseCase() }
+        verify(exactly = 0) { crashlyticsWrapper.recordException(any(), any()) }
+    }
+
+    @Test
+    fun `Use case throws generic exception`() = runTest {
+        val exceptionMessage = "Network error"
+        val exception = Exception(exceptionMessage)
+        coEvery { getDiscoverContentUseCase() } returns Result.failure(exception)
+
+        val reducerSlot = slot<Reducer<UiState>>()
+        processor.processIntent { reducer -> reducerSlot.captured = reducer }
+
+        val actualUiState = reducerSlot.captured.invoke(mockk(relaxed = true))
+
+        assertThat(actualUiState).isInstanceOf(UiState.Error::class.java)
+        val errorState = (actualUiState as UiState.Error).error
+        assertThat(errorState).isEqualTo(
+            ErrorState(
+                type = DiscoverErrors.GenericError,
+                message = exceptionMessage
+            )
+        )
+        assertThat(errorState.message).isEqualTo(exceptionMessage)
+        coVerify(exactly = 1) { getDiscoverContentUseCase() }
+    }
+
+    @Test
+    fun `Use case throws CancellationException`() = runTest {
+        val cancellationException = CancellationException("Job cancelled")
+        coEvery { getDiscoverContentUseCase() } throws cancellationException
+
+        var reducerCalled = false
+        processor.processIntent { reducerCalled = true }
+
+        assertThat(reducerCalled).isFalse()
+        coVerify(exactly = 1) { getDiscoverContentUseCase() }
+        verify(exactly = 0) { crashlyticsWrapper.recordException(any(), any()) }
+    }
+
+    @Test
+    fun `Crashlytics called on generic exception`() = runTest {
+        val exceptionMessage = "Database error"
+        val exception = Exception(exceptionMessage)
+        coEvery { getDiscoverContentUseCase() } returns Result.failure(exception)
+
+        val expectedParams = mapOf(
+            crashlyticsParams.screenName to "DiscoverScreen",
+            crashlyticsParams.className to "FetchFeatureItemsIntentProcessor",
+            crashlyticsParams.action to "fetch"
+        )
+
+        processor.processIntent { /* no-op for this test */ }
+
+        coVerify(exactly = 1) { getDiscoverContentUseCase() }
+        verify(exactly = 1) { crashlyticsWrapper.recordException(exception, expectedParams) }
+    }
+
+    @Test
+    fun `Crashlytics NOT called on CancellationException`() = runTest {
+        val cancellationException = CancellationException("Cancelled")
+        coEvery { getDiscoverContentUseCase() } throws cancellationException
+
+        processor.processIntent { /* no-op */ }
+
+        coVerify(exactly = 1) { getDiscoverContentUseCase() }
+        verify(exactly = 0) { crashlyticsWrapper.recordException(any(), any()) }
+    }
+
+    @Test
+    fun `Reducer is invoked exactly once on success`() = runTest {
+        val mockDiscover = Discover(emptyList(), emptyList())
+        coEvery { getDiscoverContentUseCase() } returns Result.success(mockDiscover)
+
+        var reducerCallCount = 0
+        processor.processIntent { reducerCallCount++ }
+
+        assertThat(reducerCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `Reducer is invoked exactly once on generic error`() = runTest {
+        val exception = Exception("Some error")
+        coEvery { getDiscoverContentUseCase() } returns Result.failure(exception)
+
+        var reducerCallCount = 0
+        processor.processIntent { reducerCallCount++ }
+
+        assertThat(reducerCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `Use case returns empty success result`() = runTest {
+        val emptyDiscover = Discover(emptyList(), emptyList())
+        val expectedUiState =
+            emptyDiscover.asDiscoverContent() // Should be UiState.DiscoverContent with empty lists
+        coEvery { getDiscoverContentUseCase() } returns Result.success(emptyDiscover)
+
+        val reducerSlot = slot<Reducer<UiState>>()
+        processor.processIntent { reducer -> reducerSlot.captured = reducer }
+
+        val actualUiState = reducerSlot.captured.invoke(mockk(relaxed = true))
+
+        assertThat(actualUiState).isEqualTo(expectedUiState)
+        assertThat((actualUiState as UiState.DiscoverContent).featuredContent).isEmpty()
+        assertThat(actualUiState.promotedContent).isEmpty()
+        coVerify(exactly = 1) { getDiscoverContentUseCase() }
+        verify(exactly = 0) { crashlyticsWrapper.recordException(any(), any()) }
+    }
+
+    @Test
+    fun `Exception message is null for generic error`() = runTest {
+        val exceptionWithNullMessage = Exception(null as String?)
+        coEvery { getDiscoverContentUseCase() } returns Result.failure(exceptionWithNullMessage)
+
+        val reducerSlot = slot<Reducer<UiState>>()
+        processor.processIntent { reducer -> reducerSlot.captured = reducer }
+
+        val actualUiState = reducerSlot.captured.invoke(mockk(relaxed = true))
+
+        assertThat(actualUiState).isInstanceOf(UiState.Error::class.java)
+        val errorState = (actualUiState as UiState.Error).error
+        assertThat(errorState).isEqualTo(
+            ErrorState(
+                type = DiscoverErrors.GenericError,
+                message = null
+            )
+        )
+        assertThat(errorState.message).isNull() // ErrorState should handle null message gracefully
+
+        verify(exactly = 1) { crashlyticsWrapper.recordException(exceptionWithNullMessage, any()) }
+    }
+
+    @Test
+    fun `Coroutine cancellation during getDiscoverContentUseCase execution`() = runTest {
+        val cancellationException = CancellationException("Cancelled during use case")
+        coEvery { getDiscoverContentUseCase() } coAnswers {
+            throw cancellationException
+        }
+
+        var reducerCalled = false
+        val job = launch { // Launch in a separate job to allow cancellation propagation
+            processor.processIntent { reducerCalled = true }
+        }
+
+        job.join() // Wait for the launched coroutine to complete or be cancelled
+
+        assertThat(reducerCalled).isFalse()
+        coVerify(exactly = 1) { getDiscoverContentUseCase() }
+        verify(exactly = 0) { crashlyticsWrapper.recordException(any(), any()) }
+    }
+}

--- a/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/utils/LambdaInvokers.kt
+++ b/feature/discover/src/test/kotlin/com/kesicollection/feature/discover/utils/LambdaInvokers.kt
@@ -1,0 +1,22 @@
+package com.kesicollection.feature.discover.utils
+
+import com.kesicollection.feature.discover.UICategory
+import com.kesicollection.feature.discover.UIContent
+
+// This interface is built to avoid Robolectric and Mockk to duplicate class definitions on sdk
+// version 23, for other versions we could use just mockk regular lambdas. But we need to test 23
+interface OnSeeAllInvoker {
+    operator fun invoke(category: UICategory)
+}
+
+// This interface is built to avoid Robolectric and Mockk to duplicate class definitions on sdk
+// version 23, for other versions we could use just mockk regular lambdas. But we need to test 23
+interface OnContentInvoker {
+    operator fun invoke(content: UIContent)
+}
+
+// This interface is built to avoid Robolectric and Mockk to duplicate class definitions on sdk
+// version 23, for other versions we could use just mockk regular lambdas. But we need to test 23
+interface OnRetryInvoker {
+    operator fun invoke()
+}


### PR DESCRIPTION
This commit introduces comprehensive unit tests for the Discover feature, covering the ViewModel, IntentProcessors, and Composables (both stateful and stateless versions of `DiscoverScreen`, as well as `DiscoverContent`).

- Added test tags to `FeatureContentSection` and `PromotedContentSection` for better UI testing.
- Implemented `DefaultIntentProcessorFactoryTest` to verify the correct creation of intent processors.
- Created `DiscoverContentTest` to test the display and interaction logic of the `DiscoverContent` composable.
- Added `DiscoverViewModelTest` to ensure the ViewModel correctly handles intents and updates its UI state.
- Developed `FetchFeatureItemsIntentProcessorTest` to validate the logic of fetching and processing discover content, including success and error scenarios.
- Implemented `StatefulDiscoverScreenTest` to test the `DiscoverScreen` composable when managed by a ViewModel, verifying state transitions and interactions.
- Added `StatelessDiscoverScreenTest` to test the `DiscoverScreen` composable with direct state provision, ensuring correct rendering for different UI states.
- Introduced fake data generators (`FakePromotedContent`, `FakeUIContent`) for use in tests.
- Added utility invoker interfaces (`OnContentInvoker`, `OnRetryInvoker`, `OnSeeAllInvoker`) to facilitate testing lambda invocations, particularly for older Android SDK versions.
- Refined `DiscoverScreen` to hide the featured content section if `featuredContent` is empty.
- Made `DiscoverScreen` composable `internal` as it's not intended for external use directly in its stateless form.

CLOSES #107