### PR TITLE
feat(discover): Add keys and content types to LazyList items

### DIFF
--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
@@ -186,13 +186,15 @@ fun DiscoverContent(
         if (uiState.featuredContent.isNotEmpty()) {
             featuredContentSection(
                 featuredContent = uiState.featuredContent,
-                onContentClick = onFeatureContentClick
+                onContentClick = onFeatureContentClick,
+                key = "featuredContentSection",
+                contentType = "featuredContentType"
             )
         }
         promotedContentSections(
             promotedContent = uiState.promotedContent,
             onSeeAllClick = rememberedOnSeeAllClick,
-            onContentClick = onPromotedContentClick
+            onContentClick = onPromotedContentClick,
         )
     }
 }

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/FeatureContentSection.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/FeatureContentSection.kt
@@ -40,11 +40,16 @@ import com.kesicollection.feature.discover.R
 import com.kesicollection.feature.discover.UIContent
 
 fun LazyListScope.featuredContentSection(
+    key: String,
+    contentType: String,
     featuredContent: List<UIContent>,
     onContentClick: (UIContent) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    item {
+    item(
+        key = key,
+        contentType = contentType
+    ) {
         Column(modifier = modifier.padding(bottom = 16.dp)) {
             Text(
                 text = stringResource(R.string.feature_discover_featured),

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/PromotedContentSection.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/PromotedContentSection.kt
@@ -58,7 +58,10 @@ fun LazyListScope.promotedContentSections(
 ) {
     promotedContent.forEach { (category, contentList) ->
         if (contentList.isNotEmpty()) {
-            item {
+            item(
+                key = category.id,
+                contentType = "promotedContentSections",
+            ) {
                 val rememberedOnSeeAllClick = remember { { onSeeAllClick(category) } }
 
                 Column(
@@ -94,7 +97,10 @@ fun LazyListScope.promotedContentSections(
                         contentPadding = PaddingValues(horizontal = 16.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        items(contentList) { content ->
+                        items(
+                            items = contentList,
+                            key = { it.id },
+                            contentType = { "PromotedCard" }) { content ->
                             PromotedCard(
                                 uiContent = content,
                                 onContentClick = onContentClick


### PR DESCRIPTION
This commit enhances the performance and stability of `LazyColumn` in the Discover screen by providing explicit `key` and `contentType` parameters to its items.

- In `FeatureContentSection.kt`:
  - Added `key` and `contentType` parameters to the `item` within `featuredContentSection`.
- In `PromotedContentSection.kt`:
  - Added `key` and `contentType` to the outer `item` that represents a category section.
  - Added `key` (using `content.id`) and `contentType` (as "PromotedCard") to the inner `items` call for individual promoted content cards.
- In `DiscoverScreen.kt`:
  - Passed appropriate `key` and `contentType` values when invoking `featuredContentSection`.
  - The `promotedContentSections` already handled keys internally, so no direct changes were needed there for keys but the `contentType` was added.

These changes help Compose efficiently identify and reuse items during recomposition and improve overall list performance, especially with dynamic content.

CLOSES #80 