### PR TITLE
feat(discover): Add keys to FeatureContentSection items

### DIFF
--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/DiscoverScreen.kt
@@ -1,5 +1,6 @@
 package com.kesicollection.feature.discover
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -119,14 +120,17 @@ internal fun DiscoverScreen(
                     .testTag(":feature:discover:LoadingDiscover")
             )
 
-            is UiState.DiscoverContent -> DiscoverContent(
-                uiState = uiState,
-                onSeeAllClick = onSeeAllClick,
-                onContentClick = onContentClick,
-                modifier = Modifier
-                    .padding(innerPadding)
-                    .testTag(":feature:discover:DiscoverContent")
-            )
+            is UiState.DiscoverContent -> {
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    DiscoverContent(
+                        uiState = uiState,
+                        onSeeAllClick = onSeeAllClick,
+                        onContentClick = onContentClick,
+                        modifier = Modifier
+                            .testTag(":feature:discover:DiscoverContent")
+                    )
+                }
+            }
 
             is UiState.Error -> {
                 ShowError(

--- a/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/FeatureContentSection.kt
+++ b/feature/discover/src/main/kotlin/com/kesicollection/feature/discover/component/FeatureContentSection.kt
@@ -63,7 +63,7 @@ fun LazyListScope.featuredContentSection(
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(featuredContent) { content ->
+                items(featuredContent, key = { it.id }) { content ->
                     FeaturedCard(
                         uiContent = content,
                         onContentClick = onContentClick,


### PR DESCRIPTION
This commit adds unique keys to the items in the `FeatureContentSection`'s `LazyRow`. This helps Compose optimize recompositions by identifying individual items.

The `DiscoverContent` composable is also wrapped in a `Box` to correctly apply padding when content is displayed. This fixes multiple recompositions that are not needed.

CLOSES #114 